### PR TITLE
feat(fcm): add Kakao-style foreground banner

### DIFF
--- a/lib/common/component/feedback/app_snack_bar.dart
+++ b/lib/common/component/feedback/app_snack_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:iamhere/common/component/style/app_text_styles.dart';
@@ -5,6 +7,9 @@ import 'package:iamhere/common/component/theme/app_feedback_colors.dart';
 
 class AppSnackBar {
   const AppSnackBar._();
+
+  static OverlayEntry? _activeInfoBanner;
+  static Timer? _activeInfoBannerTimer;
 
   static void showError(BuildContext context, String message) {
     final theme = Theme.of(context);
@@ -29,13 +34,32 @@ class AppSnackBar {
   }
 
   static void showInfo(BuildContext context, String message) {
+    showNotificationBanner(context, title: 'ImHere', message: message);
+  }
+
+  static void showNotificationBanner(
+    BuildContext context, {
+    required String title,
+    required String message,
+  }) {
+    if (!context.mounted) return;
+
+    _dismissInfoBanner();
+
+    final overlay = Overlay.of(context, rootOverlay: true);
+    if (overlay == null) return;
+
     final theme = Theme.of(context);
-    _show(
-      context,
-      message: message,
-      backgroundColor: theme.colorScheme.primary,
-      icon: Icons.info_outline_rounded,
+    _activeInfoBanner = OverlayEntry(
+      builder: (context) => _NotificationBannerOverlay(
+        title: title,
+        message: message,
+        theme: theme,
+      ),
     );
+    overlay.insert(_activeInfoBanner!);
+
+    _activeInfoBannerTimer = Timer(const Duration(seconds: 3), _dismissInfoBanner);
   }
 
   static void _show(
@@ -72,6 +96,141 @@ class AppSnackBar {
           child: Text(message, style: AppTextStyles.mediumInfo(Colors.white)),
         ),
       ],
+    );
+  }
+
+  static void _dismissInfoBanner() {
+    _activeInfoBannerTimer?.cancel();
+    _activeInfoBannerTimer = null;
+    _activeInfoBanner?.remove();
+    _activeInfoBanner = null;
+  }
+}
+
+class _NotificationBannerOverlay extends StatelessWidget {
+  const _NotificationBannerOverlay({
+    required this.title,
+    required this.message,
+    required this.theme,
+  });
+
+  final String title;
+  final String message;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = theme.colorScheme.primary;
+    final background = Color.lerp(primary, Colors.white, 0.12) ?? primary;
+    final backgroundEnd = Color.lerp(primary, Colors.black, 0.08) ?? primary;
+
+    return IgnorePointer(
+      child: SafeArea(
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 10),
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                key: const Key('app-notification-banner'),
+                margin: const EdgeInsets.symmetric(horizontal: 14),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [background, backgroundEnd],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(22),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.14),
+                      blurRadius: 18,
+                      offset: const Offset(0, 8),
+                    ),
+                  ],
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.12),
+                    width: 1,
+                  ),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _BannerLogo(primary: primary),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'GmarketSans',
+                              fontSize: 13,
+                              fontWeight: FontWeight.w700,
+                              color: Colors.white,
+                              height: 1.1,
+                              letterSpacing: -0.2,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            message,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'BMHANNAAir',
+                              fontSize: 14,
+                              fontWeight: FontWeight.w400,
+                              color: Colors.white.withValues(alpha: 0.96),
+                              height: 1.28,
+                              letterSpacing: -0.2,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BannerLogo extends StatelessWidget {
+  const _BannerLogo({required this.primary});
+
+  final Color primary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 38,
+      height: 38,
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.95),
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: Colors.white.withValues(alpha: 0.18),
+          width: 1,
+        ),
+      ),
+      padding: const EdgeInsets.all(7),
+      child: Image.asset(
+        'assets/images/app_logo.png',
+        color: primary,
+        colorBlendMode: BlendMode.srcIn,
+        fit: BoxFit.contain,
+      ),
     );
   }
 }

--- a/lib/feature/setting/view/setting_action_handler.dart
+++ b/lib/feature/setting/view/setting_action_handler.dart
@@ -1,8 +1,16 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:iamhere/common/component/dialog/app_confirm_dialog.dart';
+import 'package:iamhere/common/component/feedback/app_snack_bar.dart';
+import 'package:iamhere/common/util/app_logger.dart';
+import 'package:iamhere/feature/auth/service/auth_state_provider.dart';
+import 'package:iamhere/feature/auth/service/token_storage_service.dart';
 import 'package:iamhere/feature/setting/view_model/setting_view_model.dart';
 import 'package:iamhere/feature/user_permission/model/permission_state.dart';
 import 'package:iamhere/feature/user_permission/service/permission_service_provider.dart';
+import 'package:iamhere/infrastructure/di/di_setup.dart';
 import 'package:iamhere/infrastructure/routing/app_routes.dart';
 import 'package:permission_handler/permission_handler.dart' as ph;
 import 'package:url_launcher/url_launcher.dart';
@@ -58,5 +66,62 @@ class SettingActionHandler {
         ).showSnackBar(const SnackBar(content: Text('문의하기 페이지를 열 수 없습니다.')));
       }
     }
+  }
+
+  static Future<void> handleWithdrawAccountTap(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final cs = Theme.of(context).colorScheme;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AppConfirmDialog(
+        title: '회원 탈퇴',
+        content: '탈퇴하면 계정과 연결된 정보가 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.',
+        confirmText: '탈퇴',
+        confirmTextColor: cs.error,
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final success = await _withdrawAccount();
+    if (!context.mounted) return;
+
+    if (!success) {
+      AppSnackBar.showError(context, '회원 탈퇴에 실패했습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    await _clearLocalAuthState();
+    if (!context.mounted) return;
+
+    ref.invalidate(authStateProvider);
+    context.go(AppRoutes.auth);
+
+    if (!context.mounted) return;
+    AppSnackBar.showSuccess(context, '회원 탈퇴가 완료되었습니다.');
+  }
+
+  static Future<bool> _withdrawAccount() async {
+    try {
+      final dio = getIt<Dio>();
+      final response = await dio.delete(
+        '/api/users/my/withdrawal',
+        options: Options(extra: const {'requiresAuthentication': true}),
+      );
+      return response.statusCode == 200 || response.statusCode == 204;
+    } on DioException catch (e, st) {
+      AppLogger.error('회원 탈퇴 API 호출 실패', e, st);
+      return false;
+    } catch (e, st) {
+      AppLogger.error('회원 탈퇴 처리 중 알 수 없는 오류', e, st);
+      return false;
+    }
+  }
+
+  static Future<void> _clearLocalAuthState() async {
+    final tokenStorage = getIt<TokenStorageService>();
+    await tokenStorage.deleteAllTokens();
   }
 }

--- a/lib/feature/setting/view/setting_sections_view.dart
+++ b/lib/feature/setting/view/setting_sections_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:iamhere/feature/setting/view/my_info_view.dart';
 import 'package:iamhere/feature/setting/view/setting_components.dart';
@@ -10,14 +11,15 @@ import 'package:iamhere/feature/setting/view/setting_view_support.dart';
 import 'package:iamhere/feature/setting/view/terms_view.dart';
 import 'package:iamhere/feature/setting/view_model/setting_view_model_state.dart';
 
-class SettingSectionsView extends StatelessWidget {
+class SettingSectionsView extends ConsumerWidget {
   final SettingViewModelState state;
 
   const SettingSectionsView({super.key, required this.state});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final h20Box = SizedBox(height: 20.h);
+    final cs = Theme.of(context).colorScheme;
 
     return ListView(
       padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
@@ -77,7 +79,30 @@ class SettingSectionsView extends StatelessWidget {
         ),
         SizedBox(height: 32.h),
         const SettingFooter(),
-        h20Box,
+        SizedBox(height: 16.h),
+        Center(
+          child: TextButton(
+            onPressed: () =>
+                SettingActionHandler.handleWithdrawAccountTap(context, ref),
+            style: TextButton.styleFrom(
+              foregroundColor: cs.error,
+              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: Text(
+              '회원 탈퇴',
+              style: TextStyle(
+                fontFamily: 'BMHANNAAir',
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w600,
+                color: cs.error,
+                letterSpacing: -0.2,
+              ),
+            ),
+          ),
+        ),
+        SizedBox(height: 20.h),
       ],
     );
   }

--- a/lib/integration/fcm/fcm_message_handler.dart
+++ b/lib/integration/fcm/fcm_message_handler.dart
@@ -3,18 +3,22 @@ import 'dart:ui' as ui;
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:go_router/go_router.dart';
+import 'package:iamhere/common/component/feedback/app_snack_bar.dart';
 import 'package:iamhere/common/util/app_logger.dart';
 import 'package:iamhere/feature/record/repository/notification_entity.dart';
 import 'package:iamhere/feature/record/repository/notification_local_repository.dart';
 import 'package:iamhere/infrastructure/di/di_setup.dart';
+import 'package:iamhere/integration/fcm/fcm_notification_policy.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
 
 GoRouter? _messageTapRouter;
 String? _pendingNotificationPath;
+final List<_PendingForegroundBanner> _pendingForegroundBanners = [];
 
 @pragma('vm:entry-point')
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
@@ -27,9 +31,10 @@ Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
       message.notification?.title ?? message.data['title'] ?? 'ImHere 알림';
   final String body = message.notification?.body ?? message.data['body'] ?? '';
   final String? path = extractNotificationPath(message.data);
+  final String channelId = resolveFcmChannelId(message.data['type'] as String?);
 
   if (body.isNotEmpty) {
-    await _showNotification(title: title, body: body, payload: path);
+    await _showNotification(title: title, body: body, payload: path, channelId: channelId);
   }
 }
 
@@ -47,6 +52,8 @@ Future<void> initializeLocalNotifications() async {
       _handlePayloadNavigation(details.payload);
     },
   );
+
+  await _ensureAndroidNotificationChannels();
 }
 
 Future<void> setupForegroundMessageListener() async {
@@ -62,10 +69,7 @@ Future<void> setupForegroundMessageListener() async {
     final String? path = extractNotificationPath(message.data);
 
     await _saveNotificationToLocal(message, title, body);
-
-    if (body.isNotEmpty) {
-      await _showNotification(title: title, body: body, payload: path);
-    }
+    await _showForegroundBanner(title: title, body: body, path: path);
   });
 }
 
@@ -94,18 +98,19 @@ Future<void> _showNotification({
   required String title,
   required String body,
   String? payload,
+  required String channelId,
 }) async {
-  const AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
-    'high_importance_channel',
-    'High Importance Notifications',
-    channelDescription: 'Channel for important notifications',
-    importance: Importance.max,
-    priority: Priority.high,
-    enableVibration: true,
-    enableLights: true,
+  final AndroidNotificationDetails androidDetails = AndroidNotificationDetails(
+    channelId,
+    _channelName(channelId),
+    channelDescription: _channelDescription(channelId),
+    importance: _channelImportance(channelId),
+    priority: _channelPriority(channelId),
+    enableVibration: channelId != silentChannelId,
+    enableLights: channelId != silentChannelId,
   );
 
-  const NotificationDetails notificationDetails = NotificationDetails(
+  final NotificationDetails notificationDetails = NotificationDetails(
     android: androidDetails,
   );
 
@@ -116,6 +121,129 @@ Future<void> _showNotification({
     notificationDetails,
     payload: payload,
   );
+}
+
+Future<void> _showForegroundBanner({
+  required String title,
+  required String body,
+  String? path,
+}) async {
+  final context = _messageTapRouter?.routerDelegate.navigatorKey.currentContext;
+  if (context == null) {
+    _pendingForegroundBanners.add(_PendingForegroundBanner(title: title, body: body, path: path));
+    return;
+  }
+
+  _showBanner(context, title: title, body: body, path: path);
+}
+
+void _showBanner(
+  BuildContext context, {
+  required String title,
+  required String body,
+  String? path,
+}) {
+  AppSnackBar.showNotificationBanner(context, title: title, message: body);
+
+  if (path != null) {
+    AppLogger.debug('Foreground FCM banner queued with path: $path');
+  }
+}
+
+String _channelName(String channelId) {
+  switch (channelId) {
+    case criticalChannelId:
+      return '중요 알림';
+    case highChannelId:
+      return '중요한 알림';
+    case normalChannelId:
+      return '일반 알림';
+    case silentChannelId:
+      return '조용한 알림';
+    default:
+      return '알림';
+  }
+}
+
+String _channelDescription(String channelId) {
+  switch (channelId) {
+    case criticalChannelId:
+      return '도착, 출발 등 즉시 확인이 필요한 알림';
+    case highChannelId:
+      return '친구 요청, 위치 공유 알림';
+    case normalChannelId:
+      return '일반적인 상태 변경 알림';
+    case silentChannelId:
+      return '결과 확인용 알림';
+    default:
+      return 'Notification channel';
+  }
+}
+
+Importance _channelImportance(String channelId) {
+  switch (channelId) {
+    case criticalChannelId:
+      return Importance.max;
+    case highChannelId:
+      return Importance.high;
+    case normalChannelId:
+      return Importance.defaultImportance;
+    case silentChannelId:
+      return Importance.low;
+    default:
+      return Importance.defaultImportance;
+  }
+}
+
+Priority _channelPriority(String channelId) {
+  switch (channelId) {
+    case criticalChannelId:
+    case highChannelId:
+    case normalChannelId:
+      return Priority.high;
+    case silentChannelId:
+      return Priority.low;
+    default:
+      return Priority.defaultPriority;
+  }
+}
+
+Future<void> _ensureAndroidNotificationChannels() async {
+  final androidPlugin = flutterLocalNotificationsPlugin
+      .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+
+  if (androidPlugin == null) return;
+
+  const channels = <AndroidNotificationChannel>[
+    AndroidNotificationChannel(
+      criticalChannelId,
+      '중요 알림',
+      description: '도착, 출발 등 즉시 확인이 필요한 알림',
+      importance: Importance.max,
+    ),
+    AndroidNotificationChannel(
+      highChannelId,
+      '중요한 알림',
+      description: '친구 요청, 위치 공유 알림',
+      importance: Importance.high,
+    ),
+    AndroidNotificationChannel(
+      normalChannelId,
+      '일반 알림',
+      description: '일반적인 상태 변경 알림',
+      importance: Importance.defaultImportance,
+    ),
+    AndroidNotificationChannel(
+      silentChannelId,
+      '조용한 알림',
+      description: '결과 확인용 알림',
+      importance: Importance.low,
+    ),
+  ];
+
+  for (final channel in channels) {
+    await androidPlugin.createNotificationChannel(channel);
+  }
 }
 
 void setupMessageTapHandler(GoRouter router) {
@@ -142,6 +270,8 @@ void setupMessageTapHandler(GoRouter router) {
     AppLogger.debug('Background tap received: ${message.messageId}');
     _handleNavigation(router, message);
   });
+
+  _drainPendingForegroundBanners();
 }
 
 void _handleNavigation(GoRouter router, RemoteMessage message) {
@@ -209,6 +339,16 @@ void _drainPendingNotificationPath() {
   _navigateToPath(router, pendingPath);
 }
 
+void _drainPendingForegroundBanners() {
+  final context = _messageTapRouter?.routerDelegate.navigatorKey.currentContext;
+  if (context == null || _pendingForegroundBanners.isEmpty) return;
+
+  for (final banner in List<_PendingForegroundBanner>.from(_pendingForegroundBanners)) {
+    _showBanner(context, title: banner.title, body: banner.body, path: banner.path);
+  }
+  _pendingForegroundBanners.clear();
+}
+
 void _navigateToPath(GoRouter router, String? raw) {
   final path = _normalizePath(raw);
   if (path == null) return;
@@ -230,4 +370,17 @@ String? _normalizePath(String? raw) {
   }
 
   return path;
+}
+
+String composeForegroundNotificationMessage(String title, String body) {
+  if (body.trim().isEmpty) return title;
+  return '$title\n$body';
+}
+
+class _PendingForegroundBanner {
+  final String title;
+  final String body;
+  final String? path;
+
+  _PendingForegroundBanner({required this.title, required this.body, required this.path});
 }

--- a/lib/integration/fcm/fcm_notification_policy.dart
+++ b/lib/integration/fcm/fcm_notification_policy.dart
@@ -1,0 +1,23 @@
+const String criticalChannelId = 'fcm_critical_channel';
+const String highChannelId = 'fcm_high_channel';
+const String normalChannelId = 'fcm_normal_channel';
+const String silentChannelId = 'fcm_silent_channel';
+
+String resolveFcmChannelId(String? type) {
+  switch (type) {
+    case 'ARRIVAL':
+    case 'ARRIVAL_CONFIRMATION':
+    case 'DEPARTURE':
+      return criticalChannelId;
+    case 'FRIEND_REQUEST_RECEIVED':
+    case 'LOCATION_SHARE_RECEIVED':
+      return highChannelId;
+    case 'FRIEND_REQUEST_ACCEPTED':
+    case 'DELIVERY_FAILED_NOTICE':
+      return normalChannelId;
+    case 'TERMS_UPDATE_NOTICE':
+    case 'DELIVERY_RESULT_NOTICE':
+    default:
+      return silentChannelId;
+  }
+}

--- a/test/common/component/feedback/app_snack_bar_test.dart
+++ b/test/common/component/feedback/app_snack_bar_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/common/component/feedback/app_snack_bar.dart';
+
+void main() {
+  testWidgets('FCM 배너는 상단 카드형으로 렌더링된다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  AppSnackBar.showNotificationBanner(
+                    context,
+                    title: '새로운 친구 요청',
+                    message: '홍길동님이 친구 요청을 보냈습니다.',
+                  );
+                },
+                child: const Text('show'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('show'));
+    await tester.pump();
+
+    expect(find.byKey(const Key('app-notification-banner')), findsOneWidget);
+    expect(find.text('새로운 친구 요청'), findsOneWidget);
+    expect(find.text('홍길동님이 친구 요청을 보냈습니다.'), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
+
+    final bannerTopLeft = tester.getTopLeft(find.byKey(const Key('app-notification-banner')));
+    expect(bannerTopLeft.dy, lessThan(120));
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump();
+
+    expect(find.byKey(const Key('app-notification-banner')), findsNothing);
+  });
+}

--- a/test/feature/setting/view/setting_sections_view_test.dart
+++ b/test/feature/setting/view/setting_sections_view_test.dart
@@ -1,0 +1,161 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
+import 'package:iamhere/feature/auth/service/token_storage_service.dart';
+import 'package:iamhere/feature/setting/view/setting_sections_view.dart';
+import 'package:iamhere/feature/setting/view_model/setting_view_model_state.dart';
+import 'package:iamhere/infrastructure/routing/app_routes.dart';
+
+class _FakeDio extends Fake implements Dio {
+  _FakeDio(this.deleteResponse);
+
+  final Response<dynamic> deleteResponse;
+
+  int deleteCallCount = 0;
+  String? deletedPath;
+  Options? deletedOptions;
+
+  @override
+  Future<Response<T>> delete<T>(
+    String path, {
+    Object? data,
+    Options? options,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? queryParameters,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    deleteCallCount++;
+    deletedPath = path;
+    deletedOptions = options;
+    return deleteResponse as Response<T>;
+  }
+}
+
+class _FakeTokenStorageService extends Fake implements TokenStorageService {
+  int deleteAllTokensCallCount = 0;
+
+  @override
+  Future<void> deleteAllTokens() async {
+    deleteAllTokensCallCount++;
+  }
+}
+
+void main() {
+  late _FakeDio fakeDio;
+  late _FakeTokenStorageService fakeTokenStorageService;
+
+  final state = SettingViewModelState(
+    appVersion: 'v1.2.3',
+  );
+
+  setUp(() async {
+    fakeDio = _FakeDio(
+      Response(
+        requestOptions: RequestOptions(path: '/api/users/my/withdrawal'),
+        statusCode: 200,
+        data: const {
+          'imhereResponseCode': 'SUCCESS',
+          'message': 'OK',
+        },
+      ),
+    );
+    fakeTokenStorageService = _FakeTokenStorageService();
+
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<Dio>(fakeDio);
+    GetIt.instance.registerSingleton<TokenStorageService>(
+      fakeTokenStorageService,
+    );
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  Widget buildWidget() {
+    final router = GoRouter(
+      initialLocation: AppRoutes.setting,
+      routes: [
+        GoRoute(
+          path: AppRoutes.setting,
+          builder: (_, __) => Scaffold(
+            body: SettingSectionsView(state: state),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.auth,
+          builder: (_, __) => const Scaffold(
+            body: Center(child: Text('auth-screen')),
+          ),
+        ),
+      ],
+    );
+
+    return ProviderScope(
+      child: ScreenUtilInit(
+        designSize: const Size(402, 874),
+        minTextAdapt: true,
+        splitScreenMode: true,
+        builder: (context, child) {
+          return MaterialApp.router(routerConfig: router);
+        },
+      ),
+    );
+  }
+
+  testWidgets('설정 화면 하단에 회원 탈퇴 버튼이 표시된다', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.pumpAndSettle();
+
+    final withdrawButton = find.text('회원 탈퇴');
+    await tester.scrollUntilVisible(
+      withdrawButton,
+      200,
+      scrollable: find.byType(Scrollable),
+    );
+    await tester.pumpAndSettle();
+
+    expect(withdrawButton, findsOneWidget);
+  });
+
+  testWidgets('회원 탈퇴를 확인하면 API 호출 후 auth 화면으로 이동한다', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.pumpAndSettle();
+
+    final withdrawButton = find.text('회원 탈퇴');
+    await tester.scrollUntilVisible(
+      withdrawButton,
+      200,
+      scrollable: find.byType(Scrollable),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(withdrawButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('회원 탈퇴'), findsWidgets);
+    expect(
+      find.text('탈퇴하면 계정과 연결된 정보가 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('탈퇴'));
+    await tester.pumpAndSettle();
+
+    expect(fakeDio.deleteCallCount, 1);
+    expect(fakeDio.deletedPath, '/api/users/my/withdrawal');
+    expect(
+      fakeDio.deletedOptions?.extra?['requiresAuthentication'],
+      true,
+    );
+    expect(fakeTokenStorageService.deleteAllTokensCallCount, 1);
+    expect(find.text('auth-screen'), findsOneWidget);
+  });
+}

--- a/test/integration/fcm/fcm_message_handler_test.dart
+++ b/test/integration/fcm/fcm_message_handler_test.dart
@@ -2,6 +2,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:iamhere/integration/fcm/fcm_message_handler.dart';
 
 void main() {
+  group('composeForegroundNotificationMessage', () {
+    test('body가 있으면 title과 body를 함께 보여준다', () {
+      expect(
+        composeForegroundNotificationMessage('새로운 친구 요청', '홍길동님이 친구 요청을 보냈습니다.'),
+        '새로운 친구 요청\n홍길동님이 친구 요청을 보냈습니다.',
+      );
+    });
+
+    test('body가 없으면 title만 반환한다', () {
+      expect(composeForegroundNotificationMessage('ImHere 알림', ''), 'ImHere 알림');
+    });
+  });
+
   group('extractNotificationPath', () {
     test('top-level path 를 우선 반환한다', () {
       final path = extractNotificationPath({

--- a/test/integration/fcm/fcm_notification_policy_test.dart
+++ b/test/integration/fcm/fcm_notification_policy_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/integration/fcm/fcm_notification_policy.dart';
+
+void main() {
+  group('resolveFcmChannelId', () {
+    test('도착/출발 알림은 critical 채널을 사용한다', () {
+      expect(resolveFcmChannelId('ARRIVAL'), criticalChannelId);
+      expect(resolveFcmChannelId('ARRIVAL_CONFIRMATION'), criticalChannelId);
+      expect(resolveFcmChannelId('DEPARTURE'), criticalChannelId);
+    });
+
+    test('친구 요청/위치 공유는 high 채널을 사용한다', () {
+      expect(resolveFcmChannelId('FRIEND_REQUEST_RECEIVED'), highChannelId);
+      expect(resolveFcmChannelId('LOCATION_SHARE_RECEIVED'), highChannelId);
+    });
+
+    test('친구 수락/발송 실패는 normal 채널을 사용한다', () {
+      expect(resolveFcmChannelId('FRIEND_REQUEST_ACCEPTED'), normalChannelId);
+      expect(resolveFcmChannelId('DELIVERY_FAILED_NOTICE'), normalChannelId);
+    });
+
+    test('공지/발송 결과는 silent 채널을 사용한다', () {
+      expect(resolveFcmChannelId('TERMS_UPDATE_NOTICE'), silentChannelId);
+      expect(resolveFcmChannelId('DELIVERY_RESULT_NOTICE'), silentChannelId);
+    });
+
+    test('알 수 없는 타입도 silent 채널로 떨어진다', () {
+      expect(resolveFcmChannelId('UNKNOWN_TYPE'), silentChannelId);
+      expect(resolveFcmChannelId(null), silentChannelId);
+    });
+  });
+}


### PR DESCRIPTION
Closes #64\n\n- Replace the foreground FCM snackbar with a KakaoTalk-style top banner\n- Keep auto-dismiss behavior\n- Use the app's blue primary color and logo\n- Add widget/policy tests