### PR TITLE
fix(fcm): align routes and add notification detail

### DIFF
--- a/lib/feature/geofence/service/fcm_arrival_service.dart
+++ b/lib/feature/geofence/service/fcm_arrival_service.dart
@@ -23,7 +23,7 @@ class FcmArrivalService {
 
   /// 여러 서버 친구에게 위치 이벤트 FCM 발송
   /// [body]는 이미 {location} 등 치환이 완료된 최종 본문이어야 한다.
-  /// [location]은 본인 알림용으로 사용된다.
+  /// [location]은 서버가 도착/출발 본문을 만들 때 필요한 placeName 으로도 사용된다.
   Future<Result<void>> sendGeofenceNotifications({
     required List<String> receiverEmails,
     required String body,
@@ -39,6 +39,7 @@ class FcmArrivalService {
       final result = await _sendOne(
         receiverEmail: email,
         body: body,
+        location: location,
         type: type,
       );
       if (result is Success) {
@@ -58,6 +59,7 @@ class FcmArrivalService {
   Future<Result<void>> _sendOne({
     required String receiverEmail,
     required String body,
+    required String location,
     required String type,
   }) async {
     try {
@@ -65,7 +67,11 @@ class FcmArrivalService {
         notificationMethod: 'FCM',
         targetId: receiverEmail,
         type: type,
-        extraData: {'body': body, 'path': AppRoutes.recordNotifications},
+        extraData: {
+          'body': body,
+          'path': AppRoutes.recordNotifications,
+          'placeName': location,
+        },
       );
       final response = await _dio.post(
         _fcmArrivalPath,

--- a/lib/feature/record/repository/notification_entity.dart
+++ b/lib/feature/record/repository/notification_entity.dart
@@ -4,6 +4,7 @@ class NotificationEntity {
   final String body;
   final String senderNickname;
   final String senderEmail;
+  final String path;
   final DateTime createdAt;
 
   NotificationEntity({
@@ -12,6 +13,7 @@ class NotificationEntity {
     required this.body,
     required this.senderNickname,
     required this.senderEmail,
+    this.path = '',
     required this.createdAt,
   });
 
@@ -21,6 +23,7 @@ class NotificationEntity {
     String? body,
     String? senderNickname,
     String? senderEmail,
+    String? path,
     DateTime? createdAt,
   }) {
     return NotificationEntity(
@@ -29,6 +32,7 @@ class NotificationEntity {
       body: body ?? this.body,
       senderNickname: senderNickname ?? this.senderNickname,
       senderEmail: senderEmail ?? this.senderEmail,
+      path: path ?? this.path,
       createdAt: createdAt ?? this.createdAt,
     );
   }
@@ -40,6 +44,7 @@ class NotificationEntity {
       'body': body,
       'sender_nickname': senderNickname,
       'sender_email': senderEmail,
+      'path': path,
       'created_at': createdAt.toIso8601String(),
     };
   }
@@ -51,6 +56,7 @@ class NotificationEntity {
       body: map['body'] as String,
       senderNickname: map['sender_nickname'] as String,
       senderEmail: map['sender_email'] as String,
+      path: map['path'] as String? ?? '',
       createdAt: DateTime.parse(map['created_at'] as String),
     );
   }

--- a/lib/feature/record/view/component/notification_overview_item.dart
+++ b/lib/feature/record/view/component/notification_overview_item.dart
@@ -17,7 +17,7 @@ class NotificationOverviewItem extends StatelessWidget {
     final tt = Theme.of(context).textTheme;
 
     return GestureDetector(
-      onTap: () => AppRoutes.goToRecordNotifications(context),
+      onTap: () => AppRoutes.goToNotificationDetail(context, notification),
       child: RecordOverviewItemBase(
         leading: Container(
           width: 40.r,

--- a/lib/feature/record/view/notification_detail_view.dart
+++ b/lib/feature/record/view/notification_detail_view.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:iamhere/feature/record/repository/notification_entity.dart';
+
+class NotificationDetailView extends StatelessWidget {
+  final NotificationEntity? notification;
+
+  const NotificationDetailView({super.key, required this.notification});
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final cs = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('알림 상세', style: tt.headlineSmall),
+        centerTitle: true,
+      ),
+      body: notification == null
+          ? Center(
+              child: Text('알림 정보를 찾을 수 없습니다', style: tt.bodyMedium),
+            )
+          : SingleChildScrollView(
+              padding: EdgeInsets.all(16.r),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _DetailCard(title: '제목', value: notification!.title, cs: cs),
+                  SizedBox(height: 12.h),
+                  _DetailCard(
+                    title: '본문',
+                    value: notification!.body,
+                    cs: cs,
+                    multiline: true,
+                  ),
+                  SizedBox(height: 12.h),
+                  _DetailCard(
+                    title: '보낸 사람',
+                    value: notification!.senderNickname.isNotEmpty
+                        ? '${notification!.senderNickname} (${notification!.senderEmail})'
+                        : notification!.senderEmail,
+                    cs: cs,
+                  ),
+                  if (notification!.path.isNotEmpty) ...[
+                    SizedBox(height: 12.h),
+                    _DetailCard(title: '이동 경로', value: notification!.path, cs: cs),
+                  ],
+                  SizedBox(height: 12.h),
+                  _DetailCard(
+                    title: '받은 시각',
+                    value: _formatDateTime(notification!.createdAt),
+                    cs: cs,
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+
+  String _formatDateTime(DateTime dt) {
+    final local = dt.toLocal();
+    return '${local.year}.${local.month.toString().padLeft(2, '0')}.${local.day.toString().padLeft(2, '0')} '
+        '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+class _DetailCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final ColorScheme cs;
+  final bool multiline;
+
+  const _DetailCard({
+    required this.title,
+    required this.value,
+    required this.cs,
+    this.multiline = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      padding: EdgeInsets.all(16.r),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(14.r),
+        border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.5)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: tt.labelLarge?.copyWith(
+              color: cs.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            value,
+            style: tt.bodyLarge,
+            maxLines: multiline ? null : 3,
+            overflow: multiline ? TextOverflow.visible : TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/record/view/notification_list_view.dart
+++ b/lib/feature/record/view/notification_list_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:iamhere/common/component/feedback/imhere_loading_indicator.dart';
-import 'package:iamhere/feature/record/repository/notification_entity.dart';
+import 'package:iamhere/feature/record/view/component/notification_overview_item.dart';
 import 'package:iamhere/feature/record/view_model/notification_view_model.dart';
 
 class NotificationListView extends ConsumerWidget {
@@ -41,8 +41,9 @@ class NotificationListView extends ConsumerWidget {
                   vertical: 12.h,
                 ),
                 itemCount: notifications.length,
-                itemBuilder: (context, index) =>
-                    _buildNotificationItem(context, cs, tt, notifications[index]),
+                itemBuilder: (context, index) => NotificationOverviewItem(
+                  notification: notifications[index],
+                ),
               ),
         loading: () => Center(
           child: ImHereLoadingIndicator(height: 28),
@@ -103,87 +104,6 @@ class NotificationListView extends ConsumerWidget {
     );
   }
 
-  Widget _buildNotificationItem(
-    BuildContext context,
-    ColorScheme cs,
-    TextTheme tt,
-    NotificationEntity notification,
-  ) {
-    return Padding(
-      padding: EdgeInsets.only(bottom: 8.h),
-      child: Container(
-        decoration: BoxDecoration(
-          color: cs.surface,
-          borderRadius: BorderRadius.circular(12.r),
-          boxShadow: [
-            BoxShadow(
-              color: cs.onSurface.withValues(alpha: 0.06),
-              offset: const Offset(0, 2),
-              blurRadius: 12,
-            ),
-          ],
-        ),
-        child: Padding(
-          padding: EdgeInsets.all(14.r),
-          child: Row(
-            children: [
-              Container(
-                width: 40.r,
-                height: 40.r,
-                decoration: BoxDecoration(
-                  color: cs.primary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(10.r),
-                ),
-                child: Icon(
-                  Icons.notifications_rounded,
-                  color: cs.primary,
-                  size: 20.r,
-                ),
-              ),
-              SizedBox(width: 12.w),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      notification.title,
-                      style: tt.headlineSmall,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    SizedBox(height: 2.h),
-                    Text(
-                      notification.body,
-                      style: tt.bodyMedium,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (notification.senderNickname.isNotEmpty) ...[
-                      SizedBox(height: 2.h),
-                      Text(
-                        notification.senderNickname,
-                        style: tt.bodySmall?.copyWith(
-                          color: cs.onSurface.withValues(alpha: 0.5),
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-              SizedBox(width: 8.w),
-              Text(
-                _formatRelativeTime(notification.createdAt),
-                style: tt.bodySmall,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   void _confirmDeleteAll(BuildContext context, WidgetRef ref) {
     final tt = Theme.of(context).textTheme;
     final errorColor = Theme.of(context).colorScheme.error;
@@ -213,17 +133,5 @@ class NotificationListView extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  String _formatRelativeTime(DateTime dt) {
-    final now = DateTime.now();
-    final diff = now.difference(dt);
-
-    if (diff.inMinutes < 1) return '방금 전';
-    if (diff.inMinutes < 60) return '${diff.inMinutes}분 전';
-    if (diff.inHours < 24) return '${diff.inHours}시간 전';
-    if (diff.inDays < 7) return '${diff.inDays}일 전';
-
-    return '${dt.month}월 ${dt.day}일';
   }
 }

--- a/lib/feature/terms/view/term_detail_view.dart
+++ b/lib/feature/terms/view/term_detail_view.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:iamhere/feature/terms/service/dto/terms_list_request_dto.dart';
+import 'package:iamhere/feature/terms/view_model/terms_list_view_model.dart';
+
+class TermDetailView extends ConsumerWidget {
+  final int termId;
+
+  const TermDetailView({super.key, required this.termId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termsAsync = ref.watch(termsListViewModelProvider);
+    final tt = Theme.of(context).textTheme;
+    final cs = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('약관 상세', style: tt.headlineSmall),
+        centerTitle: true,
+      ),
+      body: termsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => Center(
+          child: Text('약관을 불러오지 못했습니다', style: tt.bodyMedium),
+        ),
+        data: (terms) {
+          TermsListRequestDto? term;
+          for (final item in terms) {
+            if (item.id == termId) {
+              term = item;
+              break;
+            }
+          }
+
+          if (term == null) {
+            return Center(
+              child: Text('약관을 찾을 수 없습니다', style: tt.bodyMedium),
+            );
+          }
+
+          return SingleChildScrollView(
+            padding: EdgeInsets.all(16.r),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _DetailCard(title: '제목', value: term.title, cs: cs),
+                SizedBox(height: 12.h),
+                _DetailCard(
+                  title: '내용',
+                  value: term.content,
+                  cs: cs,
+                  multiline: true,
+                ),
+                SizedBox(height: 12.h),
+                _DetailCard(title: '버전', value: term.version.toString(), cs: cs),
+                SizedBox(height: 12.h),
+                _DetailCard(
+                  title: '시행일',
+                  value: _formatDate(term.effectiveDate),
+                  cs: cs,
+                ),
+                SizedBox(height: 12.h),
+                _DetailCard(
+                  title: '필수 여부',
+                  value: term.isRequired ? '필수' : '선택',
+                  cs: cs,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) {
+    final local = dt.toLocal();
+    return '${local.year}.${local.month.toString().padLeft(2, '0')}.${local.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class _DetailCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final ColorScheme cs;
+  final bool multiline;
+
+  const _DetailCard({
+    required this.title,
+    required this.value,
+    required this.cs,
+    this.multiline = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+
+    return Container(
+      padding: EdgeInsets.all(16.r),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(14.r),
+        border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.5)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: tt.labelLarge?.copyWith(
+              color: cs.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            value,
+            style: tt.bodyLarge,
+            maxLines: multiline ? null : 3,
+            overflow: multiline ? TextOverflow.visible : TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/infrastructure/database/local_database_schema.dart
+++ b/lib/infrastructure/database/local_database_schema.dart
@@ -26,7 +26,8 @@ class LocalDatabaseSchema {
   /// v6: records.retry_count, records.last_error
   /// v7: geofence.awaiting_departure
   /// v8: records.delivery_event_type
-  static const int version = 8;
+  /// v9: notifications.path
+  static const int version = 9;
 
   static Future<void> onConfigure(Database db) async {
     await db.execute('PRAGMA foreign_keys = ON');
@@ -66,6 +67,9 @@ class LocalDatabaseSchema {
     }
     if (oldVersion < 8) {
       await _migrateToV8(db);
+    }
+    if (oldVersion < 9) {
+      await _migrateToV9(db);
     }
   }
 
@@ -154,6 +158,14 @@ class LocalDatabaseSchema {
     );
   }
 
+  static Future<void> _migrateToV9(Database db) async {
+    await _safeExec(
+      db,
+      'ALTER TABLE ${LocalDatabaseProperties.notificationTableName} '
+      'ADD COLUMN path TEXT DEFAULT ""',
+    );
+  }
+
   /// onUpgrade 가 부분 실행된 적이 있는 기기 등에서 같은 마이그레이션을
   /// 다시 시도해도 앱을 죽이지 않도록 한다.
   static Future<void> _safeExec(Database db, String sql) async {
@@ -219,11 +231,12 @@ class LocalDatabaseSchema {
   static const String _createNotificationsTable =
       'CREATE TABLE ${LocalDatabaseProperties.notificationTableName}'
       '(id INTEGER PRIMARY KEY AUTOINCREMENT, '
-      'title TEXT, '
-      'body TEXT, '
-      'sender_nickname TEXT DEFAULT "", '
-      'sender_email TEXT DEFAULT "", '
-      'created_at TEXT)';
+       'title TEXT, '
+       'body TEXT, '
+       'sender_nickname TEXT DEFAULT "", '
+       'sender_email TEXT DEFAULT "", '
+       'path TEXT DEFAULT "", '
+       'created_at TEXT)';
 
   static const String _createGeofenceDeliveryQueueTable =
       'CREATE TABLE IF NOT EXISTS '

--- a/lib/infrastructure/routing/app_routes.dart
+++ b/lib/infrastructure/routing/app_routes.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:iamhere/feature/record/repository/notification_entity.dart';
 
 /// 앱의 모든 경로를 한 곳에서 관리합니다.
 ///
@@ -24,9 +25,11 @@ class AppRoutes {
   static const String friendRestrictions = '/friend/restrictions';
   static const String record = '/record';
   static const String recordNotifications = '/record/notifications';
+  static const String recordNotificationDetail = '/record/notifications/detail';
   static const String recordFriendRequests = '/record/friend-requests';
   static const String recordSendHistory = '/record/send-history';
   static const String setting = '/setting';
+  static const String termsDetail = '/terms-detail/:termId';
 
   /// BottomNavigationBar 탭 순서와 일치해야 합니다.
   static const List<String> mainTabs = [geofence, contact, record, setting];
@@ -54,9 +57,16 @@ class AppRoutes {
       context.push(friendRestrictions);
   static void goToRecordNotifications(BuildContext context) =>
       context.push(recordNotifications);
+  static void goToNotificationDetail(
+    BuildContext context,
+    NotificationEntity notification,
+  ) =>
+      context.push(recordNotificationDetail, extra: notification);
   static void goToRecordFriendRequests(BuildContext context) =>
       context.push(recordFriendRequests);
   static void goToRecordSendHistory(BuildContext context) =>
       context.push(recordSendHistory);
   static void goToGeofence(BuildContext context) => context.go(geofence);
+  static void goToTermsDetail(BuildContext context, int termId) =>
+      context.push('/terms-detail/$termId');
 }

--- a/lib/infrastructure/routing/routers.dart
+++ b/lib/infrastructure/routing/routers.dart
@@ -9,12 +9,15 @@ import 'package:iamhere/feature/friend/view/friend_request_list_view.dart';
 import 'package:iamhere/feature/friend/view/friend_restriction_list_view.dart';
 import 'package:iamhere/feature/geofence/view/geofence_enroll/geofence_enroll_view.dart';
 import 'package:iamhere/feature/geofence/view/geofence_list/geofence_list_view.dart';
+import 'package:iamhere/feature/record/repository/notification_entity.dart';
+import 'package:iamhere/feature/record/view/notification_detail_view.dart';
 import 'package:iamhere/feature/record/view/notification_list_view.dart';
 import 'package:iamhere/feature/record/view/record_friend_request_list_view.dart';
 import 'package:iamhere/feature/record/view/record_view.dart';
 import 'package:iamhere/feature/record/view/send_history_list_view.dart';
 import 'package:iamhere/feature/setting/view/setting_view.dart';
 import 'package:iamhere/feature/terms/view/terms_list_view.dart';
+import 'package:iamhere/feature/terms/view/term_detail_view.dart';
 import 'package:iamhere/feature/user_permission/view/battery_optimization_guide_view.dart';
 import 'package:iamhere/feature/user_permission/view/location_permission_guide_view.dart';
 import 'package:iamhere/feature/user_permission/view/user_permission_prep_view.dart';
@@ -35,6 +38,16 @@ final List<RouteBase> appRoutes = [
       context: context,
       state: state,
       child: const TermsListView(),
+    ),
+  ),
+  GoRoute(
+    path: AppRoutes.termsDetail,
+    pageBuilder: (context, state) => buildPageWithSimpleTransition(
+      context: context,
+      state: state,
+      child: TermDetailView(
+        termId: int.tryParse(state.pathParameters['termId'] ?? '') ?? -1,
+      ),
     ),
   ),
   GoRoute(
@@ -97,6 +110,16 @@ final List<RouteBase> appRoutes = [
         ),
         routes: [
           GoRoute(
+            path: 'detail',
+            pageBuilder: (context, state) => buildPageWithSimpleTransition(
+              context: context,
+              state: state,
+              child: NotificationDetailView(
+                notification: state.extra as NotificationEntity?,
+              ),
+            ),
+          ),
+          GoRoute(
             path: 'add',
             pageBuilder: (context, state) => buildPageWithSimpleTransition(
               context: context,
@@ -136,6 +159,16 @@ final List<RouteBase> appRoutes = [
               context: context,
               state: state,
               child: const NotificationListView(),
+            ),
+          ),
+          GoRoute(
+            path: 'notifications/detail',
+            pageBuilder: (context, state) => buildPageWithSimpleTransition(
+              context: context,
+              state: state,
+              child: NotificationDetailView(
+                notification: state.extra as NotificationEntity?,
+              ),
             ),
           ),
           GoRoute(

--- a/lib/integration/fcm/fcm_message_handler.dart
+++ b/lib/integration/fcm/fcm_message_handler.dart
@@ -68,7 +68,7 @@ Future<void> setupForegroundMessageListener() async {
         message.notification?.body ?? message.data['body'] ?? '';
     final String? path = extractNotificationPath(message.data);
 
-    await _saveNotificationToLocal(message, title, body);
+    await _saveNotificationToLocal(message, title, body, path);
     await _showForegroundBanner(title: title, body: body, path: path);
   });
 }
@@ -77,6 +77,7 @@ Future<void> _saveNotificationToLocal(
   RemoteMessage message,
   String title,
   String body,
+  String? path,
 ) async {
   try {
     final repository = getIt<NotificationLocalRepository>();
@@ -85,6 +86,7 @@ Future<void> _saveNotificationToLocal(
       body: body,
       senderNickname: message.data['senderNickname'] ?? '',
       senderEmail: message.data['senderEmail'] ?? '',
+      path: path ?? '',
       createdAt: DateTime.now(),
     );
     await repository.save(entity);

--- a/test/feature/geofence/service/fcm_arrival_service_test.dart
+++ b/test/feature/geofence/service/fcm_arrival_service_test.dart
@@ -1,0 +1,62 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/common/base/result/result.dart';
+import 'package:iamhere/feature/friend/service/fcm_notification_service.dart';
+import 'package:iamhere/feature/geofence/service/fcm_arrival_service.dart';
+
+class RecordingDio extends Fake implements Dio {
+  String? capturedPath;
+  Map<String, dynamic>? capturedData;
+
+  @override
+  Future<Response<T>> post<T>(
+    String path, {
+    data,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+    Map<String, dynamic>? queryParameters,
+  }) async {
+    capturedPath = path;
+    capturedData = Map<String, dynamic>.from(data as Map);
+    return Response<T>(
+      data: {
+        'imhereResponseCode': 'SUCCESS',
+        'message': '알림이 발송 큐에 등록되었습니다.',
+        'data': null,
+      } as T,
+      statusCode: 202,
+      requestOptions: RequestOptions(path: path),
+    );
+  }
+}
+
+class FakeFcmNotificationService extends Fake implements FcmNotificationService {}
+
+void main() {
+  late RecordingDio mockDio;
+  late FakeFcmNotificationService mockFcmNotificationService;
+  late FcmArrivalService sut;
+
+  setUp(() {
+    mockDio = RecordingDio();
+    mockFcmNotificationService = FakeFcmNotificationService();
+    sut = FcmArrivalService(mockDio, mockFcmNotificationService);
+  });
+
+  test('도착 FCM payload 에 placeName 이 포함된다', () async {
+    final result = await sut.sendGeofenceNotifications(
+      receiverEmails: ['server@example.com'],
+      body: '도착 본문',
+      location: '우리집 (서울 강남구)',
+      type: 'ARRIVAL',
+    );
+
+    expect(result, isA<Success<void>>());
+
+    expect(mockDio.capturedPath, '/api/notifications');
+    final payload = mockDio.capturedData!;
+    expect(payload['extraData']['placeName'], '우리집 (서울 강남구)');
+  });
+}

--- a/test/feature/record/view/notification_detail_view_test.dart
+++ b/test/feature/record/view/notification_detail_view_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:iamhere/feature/record/repository/notification_entity.dart';
+import 'package:iamhere/feature/record/view/component/notification_overview_item.dart';
+import 'package:iamhere/feature/record/view/notification_detail_view.dart';
+import 'package:iamhere/infrastructure/routing/app_routes.dart';
+
+void main() {
+  final notification = NotificationEntity(
+    title: '도착 알림',
+    body: '홍길동님이 도착했습니다.',
+    senderNickname: '홍길동',
+    senderEmail: 'hong@example.com',
+    path: '/record/notifications',
+    createdAt: DateTime(2026, 6, 28, 10, 30),
+  );
+
+  Widget buildWidget() {
+    final router = GoRouter(
+      initialLocation: AppRoutes.recordNotifications,
+      routes: [
+        GoRoute(
+          path: AppRoutes.recordNotifications,
+          builder: (_, __) => Scaffold(
+            body: NotificationOverviewItem(notification: notification),
+          ),
+        ),
+        GoRoute(
+          path: AppRoutes.recordNotificationDetail,
+          builder: (_, state) => NotificationDetailView(
+            notification: state.extra as NotificationEntity?,
+          ),
+        ),
+      ],
+    );
+
+    return ProviderScope(
+      child: ScreenUtilInit(
+        designSize: const Size(402, 874),
+        builder: (context, child) => MaterialApp.router(routerConfig: router),
+      ),
+    );
+  }
+
+  testWidgets('알림 항목을 탭하면 상세 페이지로 이동한다', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('도착 알림'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('알림 상세'), findsOneWidget);
+    expect(find.text('이동 경로'), findsOneWidget);
+    expect(find.text('/record/notifications'), findsOneWidget);
+  });
+
+  testWidgets('상세 페이지는 알림 정보를 렌더링한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: ScreenUtilInit(
+          designSize: const Size(402, 874),
+          builder: (context, child) => MaterialApp(
+            home: NotificationDetailView(notification: notification),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('도착 알림'), findsOneWidget);
+    expect(find.text('홍길동 (hong@example.com)'), findsOneWidget);
+    expect(find.text('/record/notifications'), findsOneWidget);
+  });
+}

--- a/test/infrastructure/database/local_database_schema_test.dart
+++ b/test/infrastructure/database/local_database_schema_test.dart
@@ -44,12 +44,12 @@ void main() {
       expect(cols, contains('address'));
     });
 
-    test('notifications 테이블에 sender_nickname / sender_email 컬럼이 존재한다', () async {
+    test('notifications 테이블에 sender_nickname / sender_email / path 컬럼이 존재한다', () async {
       final cols = await _columnNames(
         db,
         LocalDatabaseProperties.notificationTableName,
       );
-      expect(cols, containsAll(['sender_nickname', 'sender_email']));
+      expect(cols, containsAll(['sender_nickname', 'sender_email', 'path']));
     });
 
     test('현재 스키마 버전이 LocalDatabaseSchema.version 과 일치해야 한다', () async {
@@ -97,7 +97,7 @@ void main() {
       expect(cols, contains('address'));
     });
 
-    test('v1 에 없던 notifications sender_* 컬럼이 마이그레이션 후 추가된다', () async {
+    test('v1 에 없던 notifications sender_* / path 컬럼이 마이그레이션 후 추가된다', () async {
       final handle = await TestDatabaseFactory.openMigratedFromV1();
       addTearDown(handle.dispose);
 
@@ -105,7 +105,7 @@ void main() {
         handle.database,
         LocalDatabaseProperties.notificationTableName,
       );
-      expect(cols, containsAll(['sender_nickname', 'sender_email']));
+      expect(cols, containsAll(['sender_nickname', 'sender_email', 'path']));
     });
 
     test('v1 에 없던 geofence_delivery_queue 테이블이 마이그레이션 후 추가된다', () async {
@@ -246,6 +246,19 @@ void main() {
       );
       expect(rows, hasLength(1));
       expect(rows.first['delivery_event_type'], 'arrival');
+    });
+  });
+
+  group('LocalDatabaseSchema (notifications.path migration)', () {
+    test('옛 스키마에서 최신으로 마이그레이션하면 notifications.path 컬럼이 추가된다', () async {
+      final handle = await TestDatabaseFactory.openMigratedFromV1();
+      addTearDown(handle.dispose);
+
+      final cols = await _columnNames(
+        handle.database,
+        LocalDatabaseProperties.notificationTableName,
+      );
+      expect(cols, contains('path'));
     });
   });
 }

--- a/test/infrastructure/database/service/notification_database_service_test.dart
+++ b/test/infrastructure/database/service/notification_database_service_test.dart
@@ -22,6 +22,7 @@ void main() {
     String body = '메시지',
     String nickname = '엄마',
     String email = 'a@example.com',
+    String path = '/record/notifications',
     DateTime? createdAt,
   }) =>
       NotificationEntity(
@@ -29,6 +30,7 @@ void main() {
         body: body,
         senderNickname: nickname,
         senderEmail: email,
+        path: path,
         createdAt: createdAt ?? DateTime(2026, 4, 29, 10),
       );
 
@@ -38,6 +40,7 @@ void main() {
     final all = await sut.findAll();
     expect(all.single.senderNickname, '엄마');
     expect(all.single.senderEmail, 'mom@example.com');
+    expect(all.single.path, '/record/notifications');
   });
 
   test('findAll 은 created_at 내림차순(최신부터) 으로 반환한다', () async {


### PR DESCRIPTION
Closes #71\n\nSummary\n- Align FCM deep-link routes with mobile GoRouter paths\n- Add notification detail page and route\n- Persist notification path from FCM payload\n- Ensure geofence FCM payload includes placeName for ARRIVAL/DEPARTURE\n\nVerification\n- flutter test test/feature/geofence/service/fcm_arrival_service_test.dart test/feature/geofence/background/geofence_delivery_pipeline_test.dart test/feature/record/view/notification_detail_view_test.dart test/infrastructure/database/local_database_schema_test.dart test/infrastructure/database/service/notification_database_service_test.dart test/integration/fcm/fcm_message_handler_test.dart test/infrastructure/routing/auth_redirect_policy_test.dart\n\nNotes\n- FCM click navigation now uses saved notification path plus detail route support.