### PR TITLE
[Feature] F05. Flutter 셸과 네이티브 브릿지 호스트

### DIFF
--- a/lib/integration/firebase/firebase_remote_service.dart
+++ b/lib/integration/firebase/firebase_remote_service.dart
@@ -5,6 +5,7 @@ import 'package:iamhere/common/util/app_logger.dart';
 
 class FirebaseRemoteService {
   static final String baseUrl = 'base_url';
+  static const String webAppUrl = 'web_app_url';
 
   final FirebaseRemoteConfig _remoteConfig = FirebaseRemoteConfig.instance;
 
@@ -37,5 +38,10 @@ class FirebaseRemoteService {
       return null;
     }
     return value;
+  }
+
+  String? get webAppUrlOrNull {
+    final value = _remoteConfig.getString(webAppUrl).trim();
+    return value.isEmpty ? null : value;
   }
 }

--- a/lib/shell/bridge/bridge_event_emitter.dart
+++ b/lib/shell/bridge/bridge_event_emitter.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:iamhere/shell/bridge/bridge_rpc_server.dart';
+import 'package:iamhere/shell/bridge/generated/bridge_contract.generated.dart';
+
+typedef JavaScriptRunner = Future<void> Function(String script);
+
+class BridgeEventEmitter {
+  final JavaScriptRunner _runJavaScript;
+
+  const BridgeEventEmitter(this._runJavaScript);
+
+  Future<void> emit(String event, [Object? payload]) {
+    if (!bridgeEventNames.contains(event)) {
+      throw ArgumentError.value(event, 'event', 'Unknown bridge event');
+    }
+    return sendMessage(BridgeRpcServer.event(event, payload));
+  }
+
+  Future<void> sendMessage(String message) {
+    final encoded = jsonEncode(message);
+    return _runJavaScript(
+      'window.__imhereBridgeReceive && '
+      'window.__imhereBridgeReceive($encoded);',
+    );
+  }
+}

--- a/lib/shell/bridge/bridge_handler_registry.dart
+++ b/lib/shell/bridge/bridge_handler_registry.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:iamhere/shell/bridge/generated/bridge_contract.generated.dart';
+
+typedef BridgeMethodHandler = FutureOr<Object?> Function(Object? params);
+
+class BridgeMethodNotFoundException implements Exception {
+  final String method;
+
+  const BridgeMethodNotFoundException(this.method);
+
+  @override
+  String toString() => 'Bridge method is not registered: $method';
+}
+
+class BridgeHandlerRegistry {
+  static const _tokenMethods = <String>{
+    'getAccessToken',
+    'refreshAccessToken',
+    'signInWithKakao',
+    'signInWithGoogle',
+  };
+
+  final Map<String, BridgeMethodHandler> _handlers;
+
+  BridgeHandlerRegistry(Iterable<Map<String, BridgeMethodHandler>> groups)
+    : _handlers = _merge(groups);
+
+  Set<String> get registeredMethods => Set.unmodifiable(_handlers.keys);
+
+  Set<String> get missingMethods =>
+      bridgeMethodNames.toSet().difference(_handlers.keys.toSet());
+
+  bool get isComplete => missingMethods.isEmpty;
+
+  Future<Object?> invoke(String method, Object? params) async {
+    final handler = _handlers[method];
+    if (handler == null) throw BridgeMethodNotFoundException(method);
+    final result = await handler(params);
+    return _tokenMethods.contains(method)
+        ? _stripRefreshTokens(result)
+        : result;
+  }
+
+  static Map<String, BridgeMethodHandler> _merge(
+    Iterable<Map<String, BridgeMethodHandler>> groups,
+  ) {
+    final result = <String, BridgeMethodHandler>{};
+    for (final group in groups) {
+      for (final entry in group.entries) {
+        if (!bridgeMethodNames.contains(entry.key)) {
+          throw ArgumentError.value(
+            entry.key,
+            'method',
+            'Unknown bridge method',
+          );
+        }
+        if (result.containsKey(entry.key)) {
+          throw ArgumentError.value(
+            entry.key,
+            'method',
+            'Duplicate bridge method',
+          );
+        }
+        result[entry.key] = entry.value;
+      }
+    }
+    return result;
+  }
+
+  static Object? _stripRefreshTokens(Object? value) {
+    if (value is List<Object?>) {
+      return value.map(_stripRefreshTokens).toList(growable: false);
+    }
+    if (value is Map) {
+      return <String, Object?>{
+        for (final entry in value.entries)
+          if (!_isRefreshTokenKey(entry.key.toString()))
+            entry.key.toString(): _stripRefreshTokens(entry.value),
+      };
+    }
+    return value;
+  }
+
+  static bool _isRefreshTokenKey(String key) {
+    final normalised = key.replaceAll(RegExp(r'[^a-zA-Z]'), '').toLowerCase();
+    return normalised == 'refreshtoken' || normalised == 'refresh';
+  }
+}
+
+const authBridgeMethodNames = <String>{
+  'getAuthState',
+  'getAccessToken',
+  'refreshAccessToken',
+  'signInWithKakao',
+  'signInWithGoogle',
+  'signOut',
+  'withdraw',
+};
+
+const permissionAndAppBridgeMethodNames = <String>{
+  'getPermissionStatus',
+  'requestPermission',
+  'openAppSettings',
+  'getAutoSendReadiness',
+  'getAppInfo',
+  'openExternalUrl',
+  'share',
+  'haptic',
+  'setStatusBarStyle',
+  'exitApp',
+  'logEvent',
+};
+
+const geofenceAndDeviceBridgeMethodNames = <String>{
+  'registerGeofence',
+  'unregisterGeofence',
+  'setGeofenceActive',
+  'syncGeofences',
+  'getNativeGeofenceState',
+  'queryGeofences',
+  'queryRecords',
+  'queryNotifications',
+  'deleteRecord',
+  'getDeviceContacts',
+  'getCurrentPosition',
+  'getLocationServiceStatus',
+};

--- a/lib/shell/bridge/bridge_rpc_server.dart
+++ b/lib/shell/bridge/bridge_rpc_server.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:iamhere/shell/bridge/bridge_handler_registry.dart';
+
+class BridgeRpcException implements Exception {
+  final String code;
+  final String message;
+  final Object? details;
+
+  const BridgeRpcException(this.code, this.message, [this.details]);
+}
+
+class BridgeRpcServer {
+  final BridgeHandlerRegistry handlers;
+
+  const BridgeRpcServer(this.handlers);
+
+  Future<String> handle(String rawMessage) async {
+    String id = 'unknown';
+    try {
+      final decoded = jsonDecode(rawMessage);
+      if (decoded is! Map<String, dynamic>) {
+        throw const BridgeRpcException(
+          'INVALID_REQUEST',
+          'Bridge request must be a JSON object.',
+        );
+      }
+
+      id = decoded['id'] is String ? decoded['id'] as String : 'unknown';
+      if (decoded['kind'] != 'request' ||
+          decoded['id'] is! String ||
+          decoded['method'] is! String) {
+        throw const BridgeRpcException(
+          'INVALID_REQUEST',
+          'Bridge request requires kind, id, and method.',
+        );
+      }
+
+      final result = await handlers.invoke(
+        decoded['method'] as String,
+        decoded['params'],
+      );
+      return jsonEncode(<String, Object?>{
+        'kind': 'response',
+        'id': id,
+        'result': result,
+      });
+    } on BridgeMethodNotFoundException catch (error) {
+      return _error(id, 'METHOD_NOT_FOUND', error.toString());
+    } on BridgeRpcException catch (error) {
+      return _error(id, error.code, error.message, error.details);
+    } catch (error) {
+      return _error(id, 'NATIVE_ERROR', error.toString());
+    }
+  }
+
+  static String event(String event, [Object? payload]) {
+    return jsonEncode(<String, Object?>{
+      'kind': 'event',
+      'event': event,
+      if (payload != null) 'payload': payload,
+    });
+  }
+
+  static String _error(
+    String id,
+    String code,
+    String message, [
+    Object? details,
+  ]) {
+    return jsonEncode(<String, Object?>{
+      'kind': 'response',
+      'id': id,
+      'error': <String, Object?>{
+        'code': code,
+        'message': message,
+        if (details != null) 'details': details,
+      },
+    });
+  }
+}

--- a/lib/shell/bridge/delegating_bridge_handler_group.dart
+++ b/lib/shell/bridge/delegating_bridge_handler_group.dart
@@ -1,0 +1,41 @@
+import 'package:iamhere/shell/bridge/bridge_handler_registry.dart';
+
+class DelegatingBridgeHandlerGroup {
+  final Map<String, BridgeMethodHandler> handlers;
+
+  DelegatingBridgeHandlerGroup.auth(Map<String, BridgeMethodHandler> delegates)
+    : handlers = _validate('auth', authBridgeMethodNames, delegates);
+
+  DelegatingBridgeHandlerGroup.permissionAndApp(
+    Map<String, BridgeMethodHandler> delegates,
+  ) : handlers = _validate(
+        'permissionAndApp',
+        permissionAndAppBridgeMethodNames,
+        delegates,
+      );
+
+  DelegatingBridgeHandlerGroup.geofenceAndDevice(
+    Map<String, BridgeMethodHandler> delegates,
+  ) : handlers = _validate(
+        'geofenceAndDevice',
+        geofenceAndDeviceBridgeMethodNames,
+        delegates,
+      );
+
+  static Map<String, BridgeMethodHandler> _validate(
+    String group,
+    Set<String> expected,
+    Map<String, BridgeMethodHandler> delegates,
+  ) {
+    final actual = delegates.keys.toSet();
+    final missing = expected.difference(actual);
+    final extra = actual.difference(expected);
+    if (missing.isNotEmpty || extra.isNotEmpty) {
+      throw ArgumentError(
+        '$group bridge delegates mismatch '
+        '(missing: ${missing.join(', ')}, extra: ${extra.join(', ')}).',
+      );
+    }
+    return Map.unmodifiable(delegates);
+  }
+}

--- a/lib/shell/bridge/flutter_app_bridge_handlers.dart
+++ b/lib/shell/bridge/flutter_app_bridge_handlers.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:iamhere/shell/bridge/bridge_handler_registry.dart';
+import 'package:iamhere/shell/bridge/generated/bridge_contract.generated.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class FlutterAppBridgeHandlers {
+  final Future<void> Function()? onExit;
+
+  const FlutterAppBridgeHandlers({this.onExit});
+
+  Map<String, BridgeMethodHandler> build() {
+    return <String, BridgeMethodHandler>{
+      'getCapabilities': (_) => _getCapabilities(),
+      'getAppInfo': (_) => _getAppInfo(),
+      'openExternalUrl': _openExternalUrl,
+      'share': _share,
+      'haptic': _haptic,
+      'setStatusBarStyle': _setStatusBarStyle,
+      'exitApp': (_) => onExit?.call() ?? SystemNavigator.pop(),
+      'logEvent': _logEvent,
+    };
+  }
+
+  Future<Map<String, Object?>> _getCapabilities() async {
+    final info = await PackageInfo.fromPlatform();
+    return <String, Object?>{
+      'bridgeVersion': bridgeContractVersion,
+      'appVersion': info.version,
+      'platform': Platform.isIOS ? 'ios' : 'android',
+      'capabilities': <String>[
+        ...bridgeMethodNames.map((name) => 'method:$name'),
+        ...bridgeEventNames.map((name) => 'event:$name'),
+      ],
+    };
+  }
+
+  Future<Map<String, Object?>> _getAppInfo() async {
+    final info = await PackageInfo.fromPlatform();
+    final platformDispatcher = WidgetsBinding.instance.platformDispatcher;
+    return <String, Object?>{
+      'appVersion': info.version,
+      'buildNumber': info.buildNumber,
+      'platform': Platform.isIOS ? 'ios' : 'android',
+      'locale': platformDispatcher.locale.toLanguageTag(),
+      'theme': switch (platformDispatcher.platformBrightness) {
+        Brightness.dark => 'dark',
+        Brightness.light => 'light',
+      },
+    };
+  }
+
+  Future<void> _openExternalUrl(Object? params) async {
+    final url = _requiredString(params, 'url');
+    final uri = Uri.tryParse(url);
+    if (uri == null ||
+        !await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      throw StateError('Unable to open external URL.');
+    }
+  }
+
+  Future<void> _share(Object? params) async {
+    final map = _requiredMap(params);
+    await SharePlus.instance.share(
+      ShareParams(
+        text: _requiredString(map, 'text'),
+        title: map['title'] as String?,
+      ),
+    );
+  }
+
+  Future<void> _haptic(Object? params) {
+    return switch (_requiredString(params, 'style')) {
+      'light' => HapticFeedback.lightImpact(),
+      'medium' => HapticFeedback.mediumImpact(),
+      'heavy' => HapticFeedback.heavyImpact(),
+      'selection' => HapticFeedback.selectionClick(),
+      final value => throw ArgumentError.value(value, 'style'),
+    };
+  }
+
+  Future<void> _setStatusBarStyle(Object? params) async {
+    final style = _requiredString(params, 'style');
+    SystemChrome.setSystemUIOverlayStyle(
+      style == 'light' ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
+    );
+  }
+
+  Future<void> _logEvent(Object? params) async {
+    final map = _requiredMap(params);
+    final rawParameters = map['parameters'];
+    await FirebaseAnalytics.instance.logEvent(
+      name: _requiredString(map, 'name'),
+      parameters: rawParameters is Map
+          ? rawParameters.map(
+              (key, value) => MapEntry(key.toString(), value as Object),
+            )
+          : null,
+    );
+  }
+
+  static Map<String, Object?> _requiredMap(Object? params) {
+    if (params is! Map) throw const FormatException('Expected object params.');
+    return params.map((key, value) => MapEntry(key.toString(), value));
+  }
+
+  static String _requiredString(Object? params, String key) {
+    final value = _requiredMap(params)[key];
+    if (value is! String || value.trim().isEmpty) {
+      throw FormatException('Expected non-empty string "$key".');
+    }
+    return value;
+  }
+}

--- a/lib/shell/shell_event_coordinator.dart
+++ b/lib/shell/shell_event_coordinator.dart
@@ -1,0 +1,42 @@
+import 'package:iamhere/integration/fcm/fcm_message_handler.dart';
+import 'package:iamhere/shell/bridge/bridge_event_emitter.dart';
+
+class ShellEventCoordinator {
+  final BridgeEventEmitter emitter;
+
+  const ShellEventCoordinator(this.emitter);
+
+  Future<void> appResumed() => emitter.emit('onAppResumed');
+
+  Future<void> permissionChanged(String permission, String status) {
+    return emitter.emit('onPermissionChanged', <String, Object?>{
+      'permission': permission,
+      'status': status,
+    });
+  }
+
+  Future<void> connectivityChanged({
+    required bool connected,
+    required String connectionType,
+  }) {
+    return emitter.emit('onConnectivityChanged', <String, Object?>{
+      'connected': connected,
+      'connectionType': connectionType,
+    });
+  }
+
+  Future<bool> pushOpened(Map<String, dynamic> data) async {
+    final path = extractNotificationPath(data);
+    if (path == null) return false;
+    await emitter.emit('onPushOpened', <String, Object?>{'path': path});
+    return true;
+  }
+
+  Future<void> themeChanged(String theme) {
+    return emitter.emit('onThemeChanged', <String, Object?>{'theme': theme});
+  }
+
+  Future<void> androidBackPressed() {
+    return emitter.emit('onAndroidBackPressed');
+  }
+}

--- a/lib/shell/view/fatal_error_view.dart
+++ b/lib/shell/view/fatal_error_view.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:iamhere/shell/view/shell_status_view.dart';
+
+class ShellFatalErrorView extends StatelessWidget {
+  final VoidCallback onRetry;
+
+  const ShellFatalErrorView({super.key, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShellStatusView(
+      icon: Icons.error_outline_rounded,
+      title: '화면을 불러오지 못했어요',
+      message: '잠시 후 다시 시도해 주세요.',
+      actionLabel: '다시 시도',
+      onAction: onRetry,
+    );
+  }
+}

--- a/lib/shell/view/force_update_view.dart
+++ b/lib/shell/view/force_update_view.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:iamhere/shell/view/shell_status_view.dart';
+
+class ShellForceUpdateView extends StatelessWidget {
+  final VoidCallback onUpdate;
+
+  const ShellForceUpdateView({super.key, required this.onUpdate});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShellStatusView(
+      icon: Icons.system_update_rounded,
+      title: '업데이트가 필요해요',
+      message: '안전한 서비스 이용을 위해 최신 버전으로 업데이트해 주세요.',
+      actionLabel: '업데이트하기',
+      onAction: onUpdate,
+    );
+  }
+}

--- a/lib/shell/view/offline_view.dart
+++ b/lib/shell/view/offline_view.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:iamhere/shell/view/shell_status_view.dart';
+
+class ShellOfflineView extends StatelessWidget {
+  final VoidCallback onRetry;
+
+  const ShellOfflineView({super.key, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShellStatusView(
+      icon: Icons.wifi_off_rounded,
+      title: '인터넷에 연결할 수 없어요',
+      message: '연결 상태를 확인한 뒤 다시 시도해 주세요.\n자동 전송 기능은 계속 동작합니다.',
+      actionLabel: '다시 시도',
+      onAction: onRetry,
+    );
+  }
+}

--- a/lib/shell/view/shell_status_view.dart
+++ b/lib/shell/view/shell_status_view.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+class ShellStatusView extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final bool loading;
+
+  const ShellStatusView({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onAction,
+    this.loading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return ColoredBox(
+      color: colors.surface,
+      child: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 360),
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Semantics(
+                liveRegion: true,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (loading)
+                      const CircularProgressIndicator()
+                    else
+                      Icon(icon, size: 56, color: colors.primary),
+                    const SizedBox(height: 24),
+                    Text(
+                      title,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      message,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    if (actionLabel != null && onAction != null) ...[
+                      const SizedBox(height: 28),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 48,
+                        child: FilledButton(
+                          onPressed: onAction,
+                          child: Text(actionLabel!),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shell/view/splash_view.dart
+++ b/lib/shell/view/splash_view.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:iamhere/shell/view/shell_status_view.dart';
+
+class ShellSplashView extends StatelessWidget {
+  const ShellSplashView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ShellStatusView(
+      icon: Icons.location_on_outlined,
+      title: 'ImHere',
+      message: '잠시만 기다려 주세요.',
+      loading: true,
+    );
+  }
+}

--- a/lib/shell/web_url_resolver.dart
+++ b/lib/shell/web_url_resolver.dart
@@ -1,0 +1,47 @@
+import 'package:iamhere/integration/firebase/firebase_remote_service.dart';
+
+typedef RemoteWebUrlLoader = Future<String?> Function();
+
+class WebUrlResolver {
+  static const String buildFallbackUrl = String.fromEnvironment(
+    'IMHERE_WEB_URL',
+    defaultValue: 'https://fortuneki.site/app',
+  );
+
+  final RemoteWebUrlLoader _loadRemoteUrl;
+  final Uri fallbackUrl;
+
+  WebUrlResolver({required RemoteWebUrlLoader loadRemoteUrl, Uri? fallbackUrl})
+    : _loadRemoteUrl = loadRemoteUrl,
+      fallbackUrl = fallbackUrl ?? Uri.parse(buildFallbackUrl);
+
+  factory WebUrlResolver.firebase(FirebaseRemoteService remoteService) {
+    return WebUrlResolver(
+      loadRemoteUrl: () async => remoteService.webAppUrlOrNull,
+    );
+  }
+
+  Future<Uri> resolve() async {
+    try {
+      final candidate = _parse(_normalise(await _loadRemoteUrl()));
+      if (candidate != null) return candidate;
+    } catch (_) {
+      // Remote Config is a rollout switch. A fetch/read failure must always
+      // preserve the build-time rollback URL.
+    }
+    return fallbackUrl;
+  }
+
+  static Uri? _parse(String? raw) {
+    if (raw == null) return null;
+    final uri = Uri.tryParse(raw);
+    if (uri == null || !uri.hasAuthority) return null;
+    if (uri.scheme != 'https') return null;
+    return uri;
+  }
+
+  static String? _normalise(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/lib/shell/webview_host.dart
+++ b/lib/shell/webview_host.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:iamhere/shell/bridge/bridge_event_emitter.dart';
+import 'package:iamhere/shell/bridge/bridge_rpc_server.dart';
+import 'package:iamhere/shell/shell_event_coordinator.dart';
+import 'package:iamhere/shell/view/fatal_error_view.dart';
+import 'package:iamhere/shell/view/force_update_view.dart';
+import 'package:iamhere/shell/view/offline_view.dart';
+import 'package:iamhere/shell/view/splash_view.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+typedef ConnectivityProbe = Future<bool> Function();
+
+enum WebViewHostState { loading, ready, offline, forceUpdate, fatalError }
+
+class WebViewHost extends StatefulWidget {
+  final Uri initialUrl;
+  final BridgeRpcServer rpcServer;
+  final ConnectivityProbe isOnline;
+  final bool forceUpdate;
+  final VoidCallback? onUpdate;
+  final VoidCallback? onExit;
+
+  const WebViewHost({
+    super.key,
+    required this.initialUrl,
+    required this.rpcServer,
+    required this.isOnline,
+    this.forceUpdate = false,
+    this.onUpdate,
+    this.onExit,
+  });
+
+  @override
+  State<WebViewHost> createState() => _WebViewHostState();
+}
+
+class _WebViewHostState extends State<WebViewHost> with WidgetsBindingObserver {
+  late final WebViewController _controller;
+  late final BridgeEventEmitter _emitter;
+  late final ShellEventCoordinator _events;
+  WebViewHostState _state = WebViewHostState.loading;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..addJavaScriptChannel(
+        'ImHereBridge',
+        onMessageReceived: (message) {
+          unawaited(_handleBridgeMessage(message.message));
+        },
+      )
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) => _pageReady(),
+          onWebResourceError: (error) {
+            if (error.isForMainFrame == false) return;
+            unawaited(_handleLoadFailure());
+          },
+        ),
+      );
+    _emitter = BridgeEventEmitter(_controller.runJavaScript);
+    _events = ShellEventCoordinator(_emitter);
+
+    if (widget.forceUpdate) {
+      _state = WebViewHostState.forceUpdate;
+    } else {
+      unawaited(_load());
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed &&
+        _state == WebViewHostState.ready) {
+      unawaited(_events.appResumed());
+    }
+  }
+
+  Future<void> _load() async {
+    if (mounted) setState(() => _state = WebViewHostState.loading);
+    if (!await widget.isOnline()) {
+      if (mounted) setState(() => _state = WebViewHostState.offline);
+      return;
+    }
+    try {
+      await _controller.loadRequest(widget.initialUrl);
+    } catch (_) {
+      await _handleLoadFailure();
+    }
+  }
+
+  void _pageReady() {
+    if (!mounted) return;
+    setState(() => _state = WebViewHostState.ready);
+    final brightness = MediaQuery.platformBrightnessOf(context);
+    unawaited(
+      _events.themeChanged(brightness == Brightness.dark ? 'dark' : 'light'),
+    );
+  }
+
+  Future<void> _handleLoadFailure() async {
+    final online = await widget.isOnline();
+    if (!mounted) return;
+    setState(
+      () => _state = online
+          ? WebViewHostState.fatalError
+          : WebViewHostState.offline,
+    );
+  }
+
+  Future<void> _handleBridgeMessage(String message) async {
+    final response = await widget.rpcServer.handle(message);
+    await _emitter.sendMessage(response);
+  }
+
+  Future<void> _handleBack() async {
+    if (await _controller.canGoBack()) {
+      await _controller.goBack();
+      return;
+    }
+    await _events.androidBackPressed();
+    if (widget.onExit != null) {
+      widget.onExit!();
+    } else {
+      await SystemNavigator.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope<Object?>(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) unawaited(_handleBack());
+      },
+      child: switch (_state) {
+        WebViewHostState.loading => const ShellSplashView(),
+        WebViewHostState.ready => SafeArea(
+          child: WebViewWidget(controller: _controller),
+        ),
+        WebViewHostState.offline => ShellOfflineView(onRetry: _load),
+        WebViewHostState.forceUpdate => ShellForceUpdateView(
+          onUpdate: widget.onUpdate ?? () {},
+        ),
+        WebViewHostState.fatalError => ShellFatalErrorView(onRetry: _load),
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -201,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -1205,6 +1213,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: transitive
     description:
@@ -1651,37 +1675,37 @@ packages:
     source: hosted
     version: "1.2.1"
   webview_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter
-      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.0"
+    version: "4.14.1"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3"
+      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.0"
+    version: "2.15.1"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: fb46db8216131a3e55bcf44040ca808423539bc6732e7ed34fb6d8044e3d512f
+      sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.23.0"
+    version: "3.25.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dependencies:
   firebase_analytics: ^12.0.4
   package_info_plus: ^8.3.1
   firebase_remote_config: ^6.1.3
+  share_plus: ^12.0.2
+  webview_flutter: ^4.14.1
   workmanager: ^0.7.0
 
 dev_dependencies:

--- a/test/shell/bridge/bridge_rpc_server_test.dart
+++ b/test/shell/bridge/bridge_rpc_server_test.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/shell/bridge/bridge_handler_registry.dart';
+import 'package:iamhere/shell/bridge/bridge_rpc_server.dart';
+import 'package:iamhere/shell/bridge/delegating_bridge_handler_group.dart';
+
+void main() {
+  test('correlates successful responses with the request id', () async {
+    Object? delegatedParams;
+    final server = BridgeRpcServer(
+      BridgeHandlerRegistry([
+        {
+          'queryGeofences': (params) {
+            delegatedParams = params;
+            return {'items': <Object?>[], 'nextCursor': null};
+          },
+        },
+      ]),
+    );
+
+    final response =
+        jsonDecode(
+              await server.handle(
+                jsonEncode({
+                  'kind': 'request',
+                  'id': 'request-42',
+                  'method': 'queryGeofences',
+                  'params': {'limit': 20},
+                }),
+              ),
+            )
+            as Map<String, dynamic>;
+
+    expect(response['id'], 'request-42');
+    expect(response['result'], {'items': <Object?>[], 'nextCursor': null});
+    expect(delegatedParams, {'limit': 20});
+  });
+
+  test('returns a typed error for an unknown or unwired method', () async {
+    final server = BridgeRpcServer(BridgeHandlerRegistry(const []));
+    final response =
+        jsonDecode(
+              await server.handle(
+                '{"kind":"request","id":"1","method":"getAuthState"}',
+              ),
+            )
+            as Map<String, dynamic>;
+
+    expect((response['error'] as Map)['code'], 'METHOD_NOT_FOUND');
+  });
+
+  test('never exposes refresh tokens through auth responses', () async {
+    final registry = BridgeHandlerRegistry([
+      {
+        'signInWithKakao': (_) => {
+          'authState': {'authenticated': true, 'userStatus': 'active'},
+          'token': {
+            'accessToken': 'access',
+            'refreshToken': 'secret',
+            'refresh_token': 'also-secret',
+          },
+        },
+      },
+    ]);
+
+    final result =
+        await registry.invoke('signInWithKakao', null) as Map<String, Object?>;
+    final token = result['token'] as Map<String, Object?>;
+
+    expect(token['accessToken'], 'access');
+    expect(token, isNot(contains('refreshToken')));
+    expect(token, isNot(contains('refresh_token')));
+  });
+
+  test('rejects duplicate handler ownership', () {
+    expect(
+      () => BridgeHandlerRegistry([
+        {'signOut': (_) => null},
+        {'signOut': (_) => null},
+      ]),
+      throwsArgumentError,
+    );
+  });
+
+  test('requires every geofence and device delegate to be wired', () {
+    expect(
+      () => DelegatingBridgeHandlerGroup.geofenceAndDevice({
+        'queryGeofences': (_) => null,
+      }),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/shell/shell_event_coordinator_test.dart
+++ b/test/shell/shell_event_coordinator_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/shell/bridge/bridge_event_emitter.dart';
+import 'package:iamhere/shell/shell_event_coordinator.dart';
+
+void main() {
+  test('reuses FCM path extraction and emits onPushOpened', () async {
+    final scripts = <String>[];
+    final coordinator = ShellEventCoordinator(
+      BridgeEventEmitter((script) async => scripts.add(script)),
+    );
+
+    final handled = await coordinator.pushOpened({
+      'extraData': '{"path":"/record/7"}',
+    });
+
+    expect(handled, isTrue);
+    expect(scripts.single, contains('onPushOpened'));
+    expect(scripts.single, contains('/record/7'));
+  });
+
+  test('ignores push data without a valid app path', () async {
+    final scripts = <String>[];
+    final coordinator = ShellEventCoordinator(
+      BridgeEventEmitter((script) async => scripts.add(script)),
+    );
+
+    expect(await coordinator.pushOpened({'path': 'https://invalid'}), isFalse);
+    expect(scripts, isEmpty);
+  });
+}

--- a/test/shell/view/shell_status_view_test.dart
+++ b/test/shell/view/shell_status_view_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/shell/view/fatal_error_view.dart';
+import 'package:iamhere/shell/view/force_update_view.dart';
+import 'package:iamhere/shell/view/offline_view.dart';
+import 'package:iamhere/shell/view/splash_view.dart';
+
+void main() {
+  Widget app(Widget child, {ThemeMode mode = ThemeMode.light}) {
+    return MaterialApp(
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode: mode,
+      home: child,
+    );
+  }
+
+  testWidgets('renders all four native shell states', (tester) async {
+    await tester.pumpWidget(app(const ShellSplashView()));
+    expect(find.text('ImHere'), findsOneWidget);
+
+    await tester.pumpWidget(app(ShellOfflineView(onRetry: () {})));
+    expect(find.text('다시 시도'), findsOneWidget);
+
+    await tester.pumpWidget(app(ShellForceUpdateView(onUpdate: () {})));
+    expect(find.text('업데이트하기'), findsOneWidget);
+
+    await tester.pumpWidget(app(ShellFatalErrorView(onRetry: () {})));
+    expect(find.text('화면을 불러오지 못했어요'), findsOneWidget);
+  });
+
+  testWidgets('renders status screens in dark mode', (tester) async {
+    await tester.pumpWidget(
+      app(ShellOfflineView(onRetry: () {}), mode: ThemeMode.dark),
+    );
+
+    final coloredBox = tester.widget<ColoredBox>(find.byType(ColoredBox).first);
+    expect(coloredBox.color.computeLuminance(), lessThan(0.2));
+  });
+}

--- a/test/shell/web_url_resolver_test.dart
+++ b/test/shell/web_url_resolver_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/shell/web_url_resolver.dart';
+
+void main() {
+  final fallback = Uri.parse('https://fallback.example/app');
+
+  test('uses a valid HTTPS Remote Config URL', () async {
+    final resolver = WebUrlResolver(
+      loadRemoteUrl: () async => ' https://release.example/app ',
+      fallbackUrl: fallback,
+    );
+
+    expect(await resolver.resolve(), Uri.parse('https://release.example/app'));
+  });
+
+  test('falls back when the remote URL is invalid', () async {
+    final resolver = WebUrlResolver(
+      loadRemoteUrl: () async => 'http://release.example/app',
+      fallbackUrl: fallback,
+    );
+
+    expect(await resolver.resolve(), fallback);
+  });
+
+  test('falls back when Remote Config throws', () async {
+    final resolver = WebUrlResolver(
+      loadRemoteUrl: () async => throw StateError('offline'),
+      fallbackUrl: fallback,
+    );
+
+    expect(await resolver.resolve(), fallback);
+  });
+}


### PR DESCRIPTION
## 연결 이슈

Refs #81

## 변경 목적

F05 Flutter WebView 셸과 F04 브릿지의 네이티브 RPC 호스트를 추가합니다. 선행 PR #80 위의 stacked PR입니다.

## 대상 플랫폼

- [x] Android
- [x] iOS
- [ ] Web
- [ ] 플랫폼 공통 또는 무관

## 주요 변경 사항

- webview_flutter 호스트, JavaScriptChannel RPC 왕복, 로딩/오류 처리
- Remote Config `web_app_url` + HTTPS 검증 + 빌드 시점 폴백
- 스플래시·오프라인·강제 업데이트·치명적 오류 네이티브 화면
- 인증 응답에서 refresh token을 재귀적으로 제거하는 보안 경계
- 인증·권한·앱 및 지오펜스·DB·기기 delegate 그룹의 완전성 검증
- 앱 정보·외부 URL·공유·햅틱·상태바·종료·분석 Flutter 핸들러
- 앱 재개·권한·연결·푸시·테마·Android 뒤로가기 이벤트 전달

## 완료 조건 확인

- [x] WebView 호스트와 로딩·오류 상태
- [x] Remote Config URL 폴백과 검증
- [x] 네이티브 상태 화면 4종 및 다크모드
- [x] RPC/토큰 비노출/이벤트/FCM 경로 테스트
- [x] 기존 서비스에 위임하는 handler group 경계
- [x] Android 뒤로가기: WebView history 우선, 첫 화면에서만 종료

## 검증

```text
flutter analyze lib/shell lib/integration/firebase/firebase_remote_service.dart test/shell: 통과
flutter test test/shell: 12 tests 통과
전체 Flutter CI: clean branch의 기존 notification detail 테스트 2건으로 실패 가능
```

## UI 변경

네이티브 상태 화면 4종이 추가됩니다. 실제 Android/iOS WebView, 키보드, 세이프 에리어와 스토어 이동은 실기기 검토가 필요합니다.

## 위험 및 호환성

- 기존 main.dart 진입점은 교체하지 않아 현재 앱 화면 경로를 보존합니다.
- native_geofence 등록, background isolate, SQLite 전달 큐, Workmanager 재시도는 변경하지 않았습니다.
- Remote Config 값이 없거나 잘못되면 `IMHERE_WEB_URL` 빌드 값으로 폴백합니다.

## 최종 확인

- [x] 연결된 이슈의 구현 완료 조건을 충족했습니다.
- [x] 변경 범위에 맞는 테스트와 검증을 수행했습니다.
- [x] 대상 플랫폼별 영향을 확인했습니다.