### PR TITLE
[Feature] F06. 웹 API 클라이언트와 인증 상태 기반

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tanstack/react-query": "5.101.4",
     "i18next": "26.3.6",
     "pretendard": "1.3.9",
     "react": "19.2.8",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-query':
+        specifier: 5.101.4
+        version: 5.101.4(react@19.2.8)
       i18next:
         specifier: 26.3.6
         version: 26.3.6(typescript@6.0.3)
@@ -596,6 +599,14 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tanstack/query-core@5.101.4':
+    resolution: {integrity: sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==}
+
+  '@tanstack/react-query@5.101.4':
+    resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2055,6 +2066,13 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/query-core@5.101.4': {}
+
+  '@tanstack/react-query@5.101.4(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.101.4
+      react: 19.2.8
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/web/src/api/api-client.test.ts
+++ b/web/src/api/api-client.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiClient, nextSlicePageParam, unwrapEnvelope } from "./api-client";
+
+const envelope = (data: unknown) =>
+  JSON.stringify({ imhereResponseCode: "SUCCESS", message: "ok", data });
+
+describe("ApiClient", () => {
+  it("unwraps the response envelope and appends ?v=1", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      void input;
+      return new Response(envelope({ id: 7 }));
+    });
+    const client = new ApiClient(
+      "https://api.example/",
+      {
+        getAccessToken: async () => ({ accessToken: "token" }),
+        refreshAccessToken: async () => ({ accessToken: "new-token" }),
+      },
+      fetchMock,
+    );
+
+    await expect(client.request<{ id: number }>("/api/items")).resolves.toEqual(
+      {
+        id: 7,
+      },
+    );
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://api.example/api/items?v=1",
+    );
+  });
+
+  it("serializes concurrent 401 refreshes and retries once", async () => {
+    let refreshed = false;
+    const refreshAccessToken = vi.fn(async () => {
+      await Promise.resolve();
+      refreshed = true;
+      return { accessToken: "new-token" };
+    });
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        void input;
+        void init;
+        return refreshed
+          ? new Response(envelope({ ok: true }))
+          : new Response("unauthorized", { status: 401 });
+      },
+    );
+    const client = new ApiClient(
+      "https://api.example/",
+      {
+        getAccessToken: async () => ({
+          accessToken: refreshed ? "new-token" : "old-token",
+        }),
+        refreshAccessToken,
+      },
+      fetchMock,
+    );
+
+    await expect(
+      Promise.all([client.request("/a"), client.request("/b")]),
+    ).resolves.toEqual([{ ok: true }, { ok: true }]);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports caller cancellation", async () => {
+    const controller = new AbortController();
+    const client = new ApiClient(
+      "https://api.example/",
+      {
+        getAccessToken: async () => ({ accessToken: null }),
+        refreshAccessToken: async () => ({ accessToken: null }),
+      },
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          if (init?.signal?.aborted === true) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
+
+    const request = client.request("/slow", { signal: controller.signal });
+    controller.abort();
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+  });
+});
+
+describe("API response helpers", () => {
+  it("rejects malformed envelopes", () => {
+    expect(() => unwrapEnvelope({ data: 1 })).toThrow(TypeError);
+  });
+
+  it("returns the next slice index only when hasNext is true", () => {
+    expect(
+      nextSlicePageParam({ content: [], hasNext: true }, [
+        { content: [], hasNext: true },
+      ]),
+    ).toBe(1);
+    expect(
+      nextSlicePageParam({ content: [], hasNext: false }, []),
+    ).toBeUndefined();
+  });
+});

--- a/web/src/api/api-client.ts
+++ b/web/src/api/api-client.ts
@@ -1,0 +1,156 @@
+export interface ImHereEnvelope<T> {
+  data: T;
+  imhereResponseCode: string;
+  message: string;
+}
+
+export interface SliceResponse<T> {
+  content: T[];
+  hasNext: boolean;
+}
+
+export interface AccessTokenProvider {
+  getAccessToken(): Promise<{ accessToken: string | null }>;
+  refreshAccessToken(): Promise<{ accessToken: string | null }>;
+}
+
+export interface ApiRequestOptions extends RequestInit {
+  apiVersion?: number;
+  timeoutMs?: number;
+}
+
+export class ApiHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly responseBody: unknown,
+  ) {
+    super(`API request failed with status ${status}`);
+    this.name = "ApiHttpError";
+  }
+}
+
+type Fetch = typeof globalThis.fetch;
+
+export class ApiClient {
+  private refreshInFlight: Promise<string | null> | undefined;
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly tokens: AccessTokenProvider,
+    private readonly fetchImpl: Fetch = globalThis.fetch,
+  ) {}
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const { signal, cleanup } = createRequestSignal(
+      options.signal,
+      options.timeoutMs ?? 10_000,
+    );
+    try {
+      return await this.execute<T>(path, options, signal, false);
+    } finally {
+      cleanup();
+    }
+  }
+
+  private async execute<T>(
+    path: string,
+    options: ApiRequestOptions,
+    signal: AbortSignal,
+    retried: boolean,
+  ): Promise<T> {
+    const token = await this.tokens.getAccessToken();
+    const response = await this.fetchImpl(
+      buildApiUrl(this.baseUrl, path, options.apiVersion ?? 1),
+      {
+        ...options,
+        signal,
+        headers: {
+          Accept: "application/json",
+          ...(options.body === undefined
+            ? {}
+            : { "Content-Type": "application/json" }),
+          ...options.headers,
+          ...(token.accessToken === null
+            ? {}
+            : { Authorization: `Bearer ${token.accessToken}` }),
+        },
+      },
+    );
+
+    if (response.status === 401 && !retried) {
+      const refreshed = await this.refreshOnce();
+      if (refreshed !== null) {
+        return this.execute<T>(path, options, signal, true);
+      }
+    }
+
+    const body = await readBody(response);
+    if (!response.ok) throw new ApiHttpError(response.status, body);
+    return unwrapEnvelope<T>(body);
+  }
+
+  private refreshOnce() {
+    this.refreshInFlight ??= this.tokens
+      .refreshAccessToken()
+      .then(({ accessToken }) => accessToken)
+      .finally(() => {
+        this.refreshInFlight = undefined;
+      });
+    return this.refreshInFlight;
+  }
+}
+
+export function unwrapEnvelope<T>(value: unknown): T {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("imhereResponseCode" in value) ||
+    !("message" in value) ||
+    !("data" in value)
+  ) {
+    throw new TypeError("Invalid ImHere API response envelope");
+  }
+  return (value as ImHereEnvelope<T>).data;
+}
+
+export function nextSlicePageParam<T>(
+  lastPage: SliceResponse<T>,
+  pages: SliceResponse<T>[],
+) {
+  return lastPage.hasNext ? pages.length : undefined;
+}
+
+function buildApiUrl(baseUrl: string, path: string, apiVersion: number) {
+  const url = new URL(path, baseUrl);
+  url.searchParams.set("v", String(apiVersion));
+  return url;
+}
+
+async function readBody(response: Response) {
+  const text = await response.text();
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function createRequestSignal(
+  parent: AbortSignal | null | undefined,
+  timeoutMs: number,
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort("timeout"), timeoutMs);
+  const abort = () => controller.abort(parent?.reason);
+  parent?.addEventListener("abort", abort, { once: true });
+  if (parent?.aborted === true) abort();
+
+  return {
+    signal: controller.signal,
+    cleanup() {
+      clearTimeout(timeout);
+      parent?.removeEventListener("abort", abort);
+    },
+  };
+}

--- a/web/src/api/query-client.ts
+++ b/web/src/api/query-client.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -1,5 +1,7 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
 
+import { queryClient } from "@/api/query-client";
 import { createAppRouter } from "@/app/router";
 import { ThemeProvider } from "@/design-system";
 
@@ -7,8 +9,10 @@ const router = createAppRouter();
 
 export function App() {
   return (
-    <ThemeProvider>
-      <RouterProvider router={router} />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }

--- a/web/src/auth/AuthRouteGuard.tsx
+++ b/web/src/auth/AuthRouteGuard.tsx
@@ -1,0 +1,32 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+
+import { type AuthSnapshot, resolveAuthRedirect } from "./auth-redirect-policy";
+
+export interface AuthRouteGuardProps {
+  auth: AuthSnapshot;
+  autoSendReady: boolean;
+  loading?: boolean;
+}
+
+export function AuthRouteGuard({
+  auth,
+  autoSendReady,
+  loading = false,
+}: AuthRouteGuardProps) {
+  const location = useLocation();
+  if (loading) {
+    return (
+      <main className="fallback-page" aria-busy="true">
+        <p>인증 상태를 확인하고 있어요.</p>
+      </main>
+    );
+  }
+
+  const redirect = resolveAuthRedirect({
+    auth,
+    autoSendReady,
+    requestedUrl: `${location.pathname}${location.search}${location.hash}`,
+  });
+
+  return redirect === null ? <Outlet /> : <Navigate replace to={redirect} />;
+}

--- a/web/src/auth/auth-redirect-policy.test.ts
+++ b/web/src/auth/auth-redirect-policy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAuthRedirect } from "./auth-redirect-policy";
+
+const resolve = (
+  authenticated: boolean,
+  userStatus: "pending" | "active" | "inactive" | null,
+  autoSendReady: boolean,
+  requestedUrl: string,
+) =>
+  resolveAuthRedirect({
+    auth: { authenticated, userStatus },
+    autoSendReady,
+    requestedUrl,
+  });
+
+describe("resolveAuthRedirect", () => {
+  it("sends unauthenticated users to auth with redirect", () => {
+    expect(resolve(false, null, false, "/record?tab=sent")).toBe(
+      "/auth?redirect=%2Frecord%3Ftab%3Dsent",
+    );
+    expect(resolve(false, null, false, "/auth")).toBeNull();
+  });
+
+  it("sends pending users to terms consent", () => {
+    expect(resolve(false, "pending", false, "/geofence")).toBe(
+      "/terms-consent?redirect=%2Fgeofence",
+    );
+  });
+
+  it("sends inactive users to auth with an inactive reason", () => {
+    expect(resolve(false, "inactive", false, "/geofence")).toBe(
+      "/auth?reason=inactive",
+    );
+  });
+
+  it("guards active users until auto-send is ready, except guide routes", () => {
+    expect(resolve(true, "active", false, "/record")).toBe(
+      "/user-permission?redirect=%2Frecord",
+    );
+    expect(
+      resolve(true, "active", false, "/location-permission-guide"),
+    ).toBeNull();
+  });
+
+  it("returns ready users to a safe redirect or geofence", () => {
+    expect(
+      resolve(true, "active", true, "/user-permission?redirect=%2Frecord"),
+    ).toBe("/record");
+    expect(resolve(true, "active", true, "/auth")).toBe("/geofence");
+  });
+});

--- a/web/src/auth/auth-redirect-policy.ts
+++ b/web/src/auth/auth-redirect-policy.ts
@@ -1,0 +1,98 @@
+export type UserStatus = "pending" | "active" | "inactive" | null;
+
+export interface AuthSnapshot {
+  authenticated: boolean;
+  userStatus: UserStatus;
+}
+
+const routes = {
+  auth: "/auth",
+  termsConsent: "/terms-consent",
+  userPermission: "/user-permission",
+  locationGuide: "/location-permission-guide",
+  batteryGuide: "/battery-optimization-guide",
+  geofence: "/geofence",
+} as const;
+
+const permissionGuideRoutes = new Set<string>([
+  routes.userPermission,
+  routes.locationGuide,
+  routes.batteryGuide,
+]);
+
+export function resolveAuthRedirect({
+  auth,
+  autoSendReady,
+  requestedUrl,
+}: {
+  auth: AuthSnapshot;
+  autoSendReady: boolean;
+  requestedUrl: string;
+}): string | null {
+  const requested = new URL(requestedUrl, "https://app.invalid");
+  const matchedLocation = requested.pathname;
+  const redirect = requested.pathname + requested.search + requested.hash;
+
+  if (
+    !auth.authenticated &&
+    auth.userStatus !== "pending" &&
+    auth.userStatus !== "inactive"
+  ) {
+    return matchedLocation === routes.auth
+      ? null
+      : withQuery(routes.auth, "redirect", redirect);
+  }
+
+  if (auth.userStatus === "pending") {
+    return matchedLocation === routes.termsConsent
+      ? null
+      : withQuery(routes.termsConsent, "redirect", redirect);
+  }
+
+  if (auth.userStatus === "inactive") {
+    return matchedLocation === routes.auth
+      ? null
+      : withQuery(routes.auth, "reason", "inactive");
+  }
+
+  if (!autoSendReady) {
+    return permissionGuideRoutes.has(matchedLocation)
+      ? null
+      : withQuery(routes.userPermission, "redirect", redirect);
+  }
+
+  if (matchedLocation === routes.userPermission) {
+    return (
+      safeRedirect(requested.searchParams.get("redirect")) ?? routes.geofence
+    );
+  }
+
+  if (
+    matchedLocation === routes.locationGuide ||
+    matchedLocation === routes.batteryGuide
+  ) {
+    return null;
+  }
+
+  if (
+    matchedLocation === routes.auth ||
+    matchedLocation === routes.termsConsent
+  ) {
+    return (
+      safeRedirect(requested.searchParams.get("redirect")) ?? routes.geofence
+    );
+  }
+
+  return null;
+}
+
+function withQuery(path: string, key: string, value: string) {
+  const query = new URLSearchParams({ [key]: value });
+  return `${path}?${query}`;
+}
+
+function safeRedirect(value: string | null) {
+  return value?.startsWith("/") === true && !value.startsWith("//")
+    ? value
+    : null;
+}


### PR DESCRIPTION
## 연결 이슈

Closes #83

## 변경 목적

F06 웹 API 공통 계약과 Flutter `AuthRedirectPolicy`에 대응하는 React 라우팅 가드를 구현합니다. PR #82 위의 stacked PR입니다.

## 대상 플랫폼

- [ ] Android
- [ ] iOS
- [x] Web
- [ ] 플랫폼 공통 또는 무관

## 주요 변경 사항

- ImHere envelope와 SliceResponse 타입/헬퍼
- `?v=1`, Bearer access token, timeout, AbortSignal 취소
- 동시 401 시 브릿지 refresh를 한 번으로 직렬화하고 1회 재시도
- refresh token을 저장하거나 요청하지 않는 AccessTokenProvider 경계
- TanStack Query 5 provider와 기본 query client
- 미인증/pending/inactive/권한 미준비/가이드 예외/복귀 상태 머신

## 완료 조건 확인

- [x] envelope와 Slice 파싱
- [x] 버전 쿼리와 액세스 토큰
- [x] 동시 401 단일 refresh 및 1회 재시도
- [x] 요청 취소와 timeout
- [x] Flutter 상태 머신 1:1 이식 및 안전한 redirect

## 검증

```text
pnpm format:check: 통과
pnpm lint: 통과
pnpm typecheck: 통과
pnpm test: 7 files / 38 tests 통과
pnpm build: 통과
pnpm bridge:check: 통과
```

## UI 변경

해당 없음

## 위험 및 호환성

액세스 토큰은 매 요청마다 네이티브 provider에서 읽으며 localStorage/sessionStorage에 저장하지 않습니다.

## 최종 확인

- [x] 연결된 이슈의 구현 완료 조건을 충족했습니다.
- [x] 변경 범위에 맞는 테스트와 검증을 수행했습니다.
- [x] 대상 플랫폼별 영향을 확인했습니다.