### PR TITLE
[Feature] F07/T20. Web Dynamic Map 위치 선택

### DIFF
--- a/web/src/map/NaverLocationPicker.test.tsx
+++ b/web/src/map/NaverLocationPicker.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { NaverLocationPicker } from "./NaverLocationPicker";
+
+const value = {
+  latitude: 37.5665,
+  longitude: 126.978,
+  radiusMeters: 250 as const,
+};
+
+describe("NaverLocationPicker", () => {
+  it("changes between the three supported radii", () => {
+    const onChange = vi.fn();
+    render(
+      <NaverLocationPicker
+        clientId="public-client"
+        value={value}
+        onChange={onChange}
+        searchPlaces={async () => []}
+        loadSdk={async () => new Promise(() => {})}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "1km" }));
+    expect(onChange).toHaveBeenCalledWith({
+      ...value,
+      radiusMeters: 1000,
+    });
+  });
+
+  it("keeps proxy address search available when the SDK fails", async () => {
+    const onChange = vi.fn();
+    const searchPlaces = vi.fn(async () => [
+      {
+        title: "서울시청",
+        address: "서울특별시 중구 세종대로 110",
+        latitude: 37.5663,
+        longitude: 126.9779,
+      },
+    ]);
+    render(
+      <NaverLocationPicker
+        clientId="public-client"
+        value={value}
+        onChange={onChange}
+        searchPlaces={searchPlaces}
+        loadSdk={async () => {
+          throw new Error("quota");
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByText("지도를 불러오지 못했어요"),
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("장소 검색"), {
+      target: { value: "서울시청" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+    await waitFor(() => expect(searchPlaces).toHaveBeenCalledWith("서울시청"));
+    fireEvent.click(await screen.findByRole("button", { name: /서울시청/ }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...value,
+      address: "서울특별시 중구 세종대로 110",
+      latitude: 37.5663,
+      longitude: 126.9779,
+    });
+  });
+});

--- a/web/src/map/NaverLocationPicker.tsx
+++ b/web/src/map/NaverLocationPicker.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from "react";
+
+import { Button, EmptyState, TextField } from "@/design-system";
+import { loadNaverMapSdk } from "@/map/naver-map-sdk";
+import type { PlaceSearchResult } from "@/map/map-proxy-service";
+
+import "./naver-location-picker.css";
+
+export interface MapSelection {
+  address?: string;
+  latitude: number;
+  longitude: number;
+  radiusMeters: 250 | 500 | 1000;
+}
+
+interface NaverLocationPickerProps {
+  clientId: string;
+  onChange: (selection: MapSelection) => void;
+  searchPlaces: (
+    query: string,
+    signal?: AbortSignal,
+  ) => Promise<PlaceSearchResult[]>;
+  value: MapSelection;
+  loadSdk?: (clientId: string) => Promise<void>;
+}
+
+const radiusOptions = [250, 500, 1000] as const;
+
+export function NaverLocationPicker({
+  clientId,
+  loadSdk = loadNaverMapSdk,
+  onChange,
+  searchPlaces,
+  value,
+}: NaverLocationPickerProps) {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const markerRef = useRef<NaverMarker | undefined>(undefined);
+  const circleRef = useRef<NaverCircle | undefined>(undefined);
+  const valueRef = useRef(value);
+  const [mapFailed, setMapFailed] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<PlaceSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let mapClickListener: object | undefined;
+    let dragListener: object | undefined;
+
+    void loadSdk(clientId)
+      .then(() => {
+        const maps = window.naver?.maps;
+        const element = elementRef.current;
+        if (cancelled || maps === undefined || element === null) return;
+        const currentValue = valueRef.current;
+        const center = new maps.LatLng(
+          currentValue.latitude,
+          currentValue.longitude,
+        );
+        const map = new maps.Map(element, { center, zoom: 16 });
+        const marker = new maps.Marker({
+          map,
+          position: center,
+          draggable: true,
+        });
+        const circle = new maps.Circle({
+          map,
+          center,
+          radius: currentValue.radiusMeters,
+          strokeColor: "var(--color-primary)",
+          fillColor: "var(--color-primary-soft)",
+        });
+        markerRef.current = marker;
+        circleRef.current = circle;
+
+        const select = (coord: NaverCoordinate) => {
+          const next = {
+            ...valueRef.current,
+            latitude: coord.lat(),
+            longitude: coord.lng(),
+          };
+          marker.setPosition(coord);
+          circle.setCenter(coord);
+          onChange(next);
+        };
+        mapClickListener = maps.Event.addListener(map, "click", (event) =>
+          select(event.coord),
+        );
+        dragListener = maps.Event.addListener(marker, "dragend", (event) =>
+          select(event.coord),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setMapFailed(true);
+      });
+
+    return () => {
+      cancelled = true;
+      const maps = window.naver?.maps;
+      if (maps !== undefined && mapClickListener !== undefined) {
+        maps.Event.removeListener(mapClickListener);
+      }
+      if (maps !== undefined && dragListener !== undefined) {
+        maps.Event.removeListener(dragListener);
+      }
+    };
+  }, [clientId, loadSdk, onChange]);
+
+  useEffect(() => {
+    const maps = window.naver?.maps;
+    if (maps === undefined) return;
+    const center = new maps.LatLng(value.latitude, value.longitude);
+    markerRef.current?.setPosition(center);
+    circleRef.current?.setCenter(center);
+    circleRef.current?.setRadius(value.radiusMeters);
+  }, [value]);
+
+  async function submitSearch() {
+    const trimmed = query.trim();
+    if (trimmed.length === 0) return;
+    setSearching(true);
+    try {
+      setResults(await searchPlaces(trimmed));
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  function selectPlace(place: PlaceSearchResult) {
+    onChange({
+      ...value,
+      address: place.address,
+      latitude: place.latitude,
+      longitude: place.longitude,
+    });
+  }
+
+  return (
+    <section className="location-picker" aria-label="장소와 반경 선택">
+      <form
+        className="location-picker__search"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submitSearch();
+        }}
+      >
+        <TextField
+          label="장소 검색"
+          placeholder="주소 또는 장소명을 입력하세요"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <Button loading={searching} type="submit">
+          검색
+        </Button>
+      </form>
+
+      {mapFailed ? (
+        <EmptyState
+          title="지도를 불러오지 못했어요"
+          description="주소 검색으로 장소를 선택할 수 있어요."
+        />
+      ) : (
+        <div
+          ref={elementRef}
+          className="location-picker__map"
+          data-clarity-mask="true"
+          aria-label="네이버 지도"
+        />
+      )}
+
+      <fieldset className="location-picker__radius">
+        <legend>알림 반경</legend>
+        {radiusOptions.map((radius) => (
+          <Button
+            key={radius}
+            variant={value.radiusMeters === radius ? "primary" : "secondary"}
+            aria-pressed={value.radiusMeters === radius}
+            onClick={() => onChange({ ...value, radiusMeters: radius })}
+          >
+            {radius === 1000 ? "1km" : `${radius}m`}
+          </Button>
+        ))}
+      </fieldset>
+
+      {results.length === 0 ? null : (
+        <ul className="location-picker__results">
+          {results.map((place) => (
+            <li key={`${place.latitude}:${place.longitude}`}>
+              <button type="button" onClick={() => selectPlace(place)}>
+                <strong>{place.title}</strong>
+                <span>{place.address}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web/src/map/map-proxy-service.ts
+++ b/web/src/map/map-proxy-service.ts
@@ -1,0 +1,71 @@
+import type { ApiClient, SliceResponse } from "@/api/api-client";
+
+export interface PlaceSearchResult {
+  address: string;
+  latitude: number;
+  longitude: number;
+  title: string;
+}
+
+interface LocalSearchItem {
+  address?: string;
+  roadAddress?: string;
+  title: string;
+}
+
+interface GeocodeAddress {
+  roadAddress?: string;
+  jibunAddress?: string;
+  x: string;
+  y: string;
+}
+
+export class MapProxyService {
+  constructor(private readonly api: ApiClient) {}
+
+  async searchPlaces(query: string, signal?: AbortSignal) {
+    const search = await this.api.request<{ items: LocalSearchItem[] }>(
+      `/api/maps/local-search?query=${encodeURIComponent(query)}`,
+      { signal },
+    );
+    const results = await Promise.all(
+      search.items.map(async (item): Promise<PlaceSearchResult | null> => {
+        const address = item.roadAddress || item.address;
+        if (address === undefined) return null;
+        const geocode = await this.api.request<{ addresses: GeocodeAddress[] }>(
+          `/api/maps/geocode?query=${encodeURIComponent(address)}`,
+          { signal },
+        );
+        const coordinate = geocode.addresses[0];
+        if (coordinate === undefined) return null;
+        return {
+          title: stripHtml(item.title),
+          address: coordinate.roadAddress || coordinate.jibunAddress || address,
+          latitude: Number(coordinate.y),
+          longitude: Number(coordinate.x),
+        };
+      }),
+    );
+    return results.filter(
+      (value): value is PlaceSearchResult => value !== null,
+    );
+  }
+
+  async reverseGeocode(
+    latitude: number,
+    longitude: number,
+    signal?: AbortSignal,
+  ) {
+    return this.api.request<{ results: unknown[] }>(
+      `/api/maps/reverse-geocode?latitude=${latitude}&longitude=${longitude}`,
+      { signal },
+    );
+  }
+}
+
+function stripHtml(value: string) {
+  const document = new DOMParser().parseFromString(value, "text/html");
+  return document.body.textContent ?? value;
+}
+
+export type PlaceSearchPage = SliceResponse<PlaceSearchResult>;

--- a/web/src/map/naver-location-picker.css
+++ b/web/src/map/naver-location-picker.css
@@ -1,0 +1,65 @@
+.location-picker {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.location-picker__search {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-3);
+  align-items: end;
+}
+
+.location-picker__map {
+  min-height: 20rem;
+  overflow: hidden;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-raised);
+}
+
+.location-picker__radius {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 0;
+  border: 0;
+}
+
+.location-picker__radius legend {
+  width: 100%;
+  margin-bottom: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.location-picker__results {
+  display: grid;
+  gap: var(--space-2);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.location-picker__results button {
+  display: grid;
+  width: 100%;
+  min-height: 44px;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  color: var(--color-text);
+  text-align: left;
+  cursor: pointer;
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-md);
+}
+
+.location-picker__results span {
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 30rem) {
+  .location-picker__search {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/map/naver-map-sdk.ts
+++ b/web/src/map/naver-map-sdk.ts
@@ -1,0 +1,24 @@
+let sdkPromise: Promise<void> | undefined;
+
+export function loadNaverMapSdk(clientId: string): Promise<void> {
+  if (globalThis.window.naver?.maps !== undefined) return Promise.resolve();
+  if (!/^[a-zA-Z0-9_-]+$/.test(clientId)) {
+    return Promise.reject(new Error("Invalid Naver map client id"));
+  }
+
+  sdkPromise ??= new Promise<void>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src =
+      "https://oapi.map.naver.com/openapi/v3/maps.js" +
+      `?ncpKeyId=${encodeURIComponent(clientId)}`;
+    script.addEventListener("load", () => resolve(), { once: true });
+    script.addEventListener(
+      "error",
+      () => reject(new Error("Naver map SDK failed to load")),
+      { once: true },
+    );
+    document.head.append(script);
+  });
+  return sdkPromise;
+}

--- a/web/src/map/naver-map.d.ts
+++ b/web/src/map/naver-map.d.ts
@@ -1,0 +1,36 @@
+interface NaverCoordinate {
+  lat(): number;
+  lng(): number;
+}
+
+interface NaverMap {
+  setCenter(position: NaverCoordinate): void;
+}
+
+interface NaverMarker {
+  setPosition(position: NaverCoordinate): void;
+}
+
+interface NaverCircle {
+  setCenter(position: NaverCoordinate): void;
+  setRadius(radius: number): void;
+}
+
+interface NaverMapsApi {
+  Circle: new (options: Record<string, unknown>) => NaverCircle;
+  Event: {
+    addListener(
+      target: object,
+      event: string,
+      listener: (event: { coord: NaverCoordinate }) => void,
+    ): object;
+    removeListener(listener: object): void;
+  };
+  LatLng: new (latitude: number, longitude: number) => NaverCoordinate;
+  Map: new (element: HTMLElement, options: Record<string, unknown>) => NaverMap;
+  Marker: new (options: Record<string, unknown>) => NaverMarker;
+}
+
+interface Window {
+  naver?: { maps: NaverMapsApi };
+}


### PR DESCRIPTION
## 연결 이슈

Closes #85

## 변경 목적

F07/T20 Web Dynamic Map 위치 선택과 T19 서버 프록시 소비 계층을 구현합니다. PR #84 위의 stacked PR입니다.

## 대상 플랫폼

- [ ] Android
- [ ] iOS
- [x] Web
- [ ] 플랫폼 공통 또는 무관

## 주요 변경 사항

- 공개 `ncpKeyId`만 사용하는 Naver Web Dynamic Map SDK loader
- 지도 클릭·드래그 핀 좌표 변경과 Circle 반경 동기화
- 250m·500m·1km 반경 선택
- `/api/maps/*` 프록시만 사용하는 POI 검색/지오코딩 service
- SDK 실패 시 주소 검색 폴백
- Clarity 지도 영역 마스킹

## 완료 조건 확인

- [x] SDK 로드와 좌표 선택
- [x] 반경 원 3종
- [x] 서버 프록시 기반 POI/주소 처리
- [x] 지도 실패 폴백
- [x] Clarity 마스킹

## 검증

```text
pnpm format:check: 통과
pnpm lint: 통과
pnpm typecheck: 통과
pnpm test: 8 files / 40 tests 통과
pnpm build: 통과
```

## UI 변경

지도 선택 컴포넌트가 추가됩니다. NCP 콘솔 도메인 등록과 실제 지도 조작감은 실기기 검토가 필요합니다.

## 위험 및 호환성

지도 SDK의 public client id 외에 지오코딩·검색 secret은 웹 코드에 존재하지 않습니다. 외부 데이터 API는 server#108 프록시를 통해서만 호출합니다.

## 최종 확인

- [x] 연결된 이슈의 구현 완료 조건을 충족했습니다.
- [x] 변경 범위에 맞는 테스트와 검증을 수행했습니다.
- [x] 대상 플랫폼별 영향을 확인했습니다.