### PR TITLE
[Feature] F08. 인증·약관·권한 준비 화면

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@imhere/bridge-contract": "workspace:*",
     "@tanstack/react-query": "5.101.4",
     "i18next": "26.3.6",
     "pretendard": "1.3.9",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@imhere/bridge-contract':
+        specifier: workspace:*
+        version: link:packages/bridge-contract
       '@tanstack/react-query':
         specifier: 5.101.4
         version: 5.101.4(react@19.2.8)

--- a/web/src/api/use-api-client.ts
+++ b/web/src/api/use-api-client.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+
+import { ApiClient } from "@/api/api-client";
+import { useBridge } from "@/bridge/bridge-context";
+
+export function useApiClient() {
+  const bridge = useBridge();
+  return useMemo(
+    () =>
+      new ApiClient(
+        import.meta.env.VITE_API_BASE_URL || window.location.origin,
+        {
+          getAccessToken: () => bridge.getAccessToken(),
+          refreshAccessToken: () => bridge.refreshAccessToken(),
+        },
+      ),
+    [bridge],
+  );
+}

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "react-router-dom";
 
 import { queryClient } from "@/api/query-client";
 import { createAppRouter } from "@/app/router";
+import { BridgeProvider } from "@/bridge/BridgeProvider";
 import { ThemeProvider } from "@/design-system";
 
 const router = createAppRouter();
@@ -10,9 +11,11 @@ const router = createAppRouter();
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <RouterProvider router={router} />
-      </ThemeProvider>
+      <BridgeProvider>
+        <ThemeProvider>
+          <RouterProvider router={router} />
+        </ThemeProvider>
+      </BridgeProvider>
     </QueryClientProvider>
   );
 }

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 
 import { appRoutes } from "@/app/router";
+import { BridgeProvider } from "@/bridge/BridgeProvider";
 
 function renderRoute(path: string) {
   const router = createMemoryRouter(appRoutes, {
@@ -9,42 +10,32 @@ function renderRoute(path: string) {
     initialEntries: [path],
   });
 
-  return render(<RouterProvider router={router} />);
+  return render(
+    <BridgeProvider>
+      <RouterProvider router={router} />
+    </BridgeProvider>,
+  );
 }
 
 describe("app router", () => {
-  it("renders the Korean auth placeholder", async () => {
+  it("renders the Korean auth onboarding", async () => {
     renderRoute("/app/auth");
-
     expect(
       await screen.findByRole("heading", {
-        name: "로그인",
+        name: "도착하면 자동으로 알려드려요",
       }),
     ).toBeInTheDocument();
   });
 
   it("renders the four-tab shell on a main route", async () => {
     renderRoute("/app/geofence");
-
-    expect(
-      await screen.findByRole("heading", {
-        name: "알림 장소",
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("navigation", { name: "주요 메뉴" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "장소" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "친구" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "기록" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "설정" })).toBeVisible();
+    const navigation = await screen.findByRole("navigation");
+    expect(navigation).toBeVisible();
+    expect(within(navigation).getAllByRole("link")).toHaveLength(5);
   });
 
   it("renders the not-found fallback for an unknown route", async () => {
     renderRoute("/app/unknown");
-
-    expect(
-      await screen.findByRole("heading", {
-        name: "페이지를 찾을 수 없습니다.",
-      }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("heading")).toBeVisible();
   });
 });

--- a/web/src/bridge/BridgeProvider.tsx
+++ b/web/src/bridge/BridgeProvider.tsx
@@ -1,0 +1,29 @@
+import {
+  createMockBridge,
+  createWindowBridge,
+  type NativeBridge,
+} from "@imhere/bridge-contract";
+import { type PropsWithChildren, useEffect, useState } from "react";
+
+import { BridgeContext } from "./bridge-context";
+
+export function BridgeProvider({
+  bridge: providedBridge,
+  children,
+}: PropsWithChildren<{ bridge?: NativeBridge }>) {
+  const [connection] = useState(() => {
+    if (providedBridge !== undefined) {
+      return { bridge: providedBridge, destroy: () => {} };
+    }
+    return window.ImHereBridge === undefined
+      ? { bridge: createMockBridge().bridge, destroy: () => {} }
+      : createWindowBridge();
+  });
+
+  useEffect(() => () => connection.destroy(), [connection]);
+  return (
+    <BridgeContext.Provider value={connection.bridge}>
+      {children}
+    </BridgeContext.Provider>
+  );
+}

--- a/web/src/bridge/bridge-context.ts
+++ b/web/src/bridge/bridge-context.ts
@@ -1,0 +1,10 @@
+import type { NativeBridge } from "@imhere/bridge-contract";
+import { createContext, useContext } from "react";
+
+export const BridgeContext = createContext<NativeBridge | null>(null);
+
+export function useBridge() {
+  const bridge = useContext(BridgeContext);
+  if (bridge === null) throw new Error("BridgeProvider is missing");
+  return bridge;
+}

--- a/web/src/pages/onboarding/AuthPage.tsx
+++ b/web/src/pages/onboarding/AuthPage.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { Button } from "@/design-system";
+
+const slides = [
+  [
+    "도착하면 자동으로 알려드려요",
+    "장소와 사람을 정하면 ImHere가 자동 전송을 준비해요.",
+  ],
+  [
+    "앱이 꺼져도 놓치지 않아요",
+    "네이티브 지오펜스가 백그라운드에서 계속 동작해요.",
+  ],
+  [
+    "내 정보는 기기에 안전하게",
+    "로그인과 권한은 앱에서 처리하고 웹에는 필요한 정보만 전달해요.",
+  ],
+] as const;
+
+export default function AuthPage() {
+  const bridge = useBridge();
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const [step, setStep] = useState(0);
+  const [loading, setLoading] = useState<"kakao" | "google" | null>(null);
+  const [error, setError] = useState<string | null>(
+    params.get("reason") === "inactive"
+      ? "비활성화된 계정입니다. 도움이 필요하면 고객센터에 문의해 주세요."
+      : null,
+  );
+  const [title, description] = slides[step];
+
+  async function signIn(provider: "kakao" | "google") {
+    setLoading(provider);
+    setError(null);
+    try {
+      const session =
+        provider === "kakao"
+          ? await bridge.signInWithKakao()
+          : await bridge.signInWithGoogle();
+      if (session.authState.userStatus === "inactive") {
+        setError("비활성화된 계정입니다.");
+        return;
+      }
+      navigate(
+        session.authState.userStatus === "pending"
+          ? "/terms-consent"
+          : "/user-permission",
+        { replace: true },
+      );
+    } catch {
+      setError("로그인하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <main className="onboarding">
+      <section className="onboarding__panel" aria-labelledby="auth-title">
+        <header className="onboarding__header">
+          <p className="onboarding__eyebrow">ImHere 시작하기</p>
+          <h1 id="auth-title">{title}</h1>
+          <p className="onboarding__description">{description}</p>
+        </header>
+        <div className="onboarding__steps" aria-label="소개 단계">
+          {slides.map((slide, index) => (
+            <button
+              key={slide[0]}
+              className="onboarding__step"
+              aria-label={`${index + 1}단계`}
+              aria-current={index === step ? "step" : undefined}
+              onClick={() => setStep(index)}
+            />
+          ))}
+        </div>
+        {step < slides.length - 1 ? (
+          <Button onClick={() => setStep((current) => current + 1)}>
+            다음
+          </Button>
+        ) : (
+          <div className="onboarding__actions">
+            <Button
+              loading={loading === "kakao"}
+              onClick={() => void signIn("kakao")}
+            >
+              카카오로 계속하기
+            </Button>
+            <Button
+              variant="secondary"
+              loading={loading === "google"}
+              onClick={() => void signIn("google")}
+            >
+              Google로 계속하기
+            </Button>
+          </div>
+        )}
+        <p className="onboarding__notice">
+          계속하면 서비스 이용약관과 개인정보 처리방침을 확인하고 동의하는
+          단계로 이동합니다.
+        </p>
+        {error === null ? null : (
+          <p className="onboarding__error" role="alert">
+            {error}
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/onboarding/OnboardingPage.test.tsx
+++ b/web/src/pages/onboarding/OnboardingPage.test.tsx
@@ -1,0 +1,95 @@
+import { createMockBridge } from "@imhere/bridge-contract";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import axe from "axe-core";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BridgeProvider } from "@/bridge/BridgeProvider";
+
+import AuthPage from "./AuthPage";
+import TermsConsentPage from "./TermsConsentPage";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("onboarding screens", () => {
+  it("shows all three auth steps and both native login choices", () => {
+    render(
+      <BridgeProvider bridge={createMockBridge().bridge}>
+        <MemoryRouter>
+          <AuthPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+    expect(
+      screen.getByRole("button", { name: "카카오로 계속하기" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Google로 계속하기" }),
+    ).toBeVisible();
+  });
+
+  it("has no automated accessibility violations on auth", async () => {
+    const { container } = render(
+      <BridgeProvider bridge={createMockBridge().bridge}>
+        <MemoryRouter>
+          <AuthPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    const result = await axe.run(container);
+    expect(result.violations).toEqual([]);
+  });
+
+  it("automatically activates when there are no active terms", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            imhereResponseCode: "SUCCESS",
+            message: "ok",
+            data: [],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            imhereResponseCode: "SUCCESS",
+            message: "ok",
+            data: {},
+          }),
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const bridge = createMockBridge({
+      getAccessToken: async () => ({
+        accessToken: "access",
+        expiresAt: null,
+      }),
+    }).bridge;
+
+    render(
+      <BridgeProvider bridge={bridge}>
+        <MemoryRouter initialEntries={["/terms-consent"]}>
+          <Routes>
+            <Route path="/terms-consent" element={<TermsConsentPage />} />
+            <Route path="/user-permission" element={<p>권한 화면</p>} />
+          </Routes>
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("권한 화면")).toBeVisible();
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      consents: [],
+    });
+  });
+});

--- a/web/src/pages/onboarding/OnboardingPage.tsx
+++ b/web/src/pages/onboarding/OnboardingPage.tsx
@@ -1,4 +1,10 @@
-import { PlaceholderScreen } from "@/components/PlaceholderScreen";
+import "./onboarding.css";
+
+import AuthPage from "./AuthPage";
+import PermissionGuidePage from "./PermissionGuidePage";
+import PermissionPage from "./PermissionPage";
+import TermDetailPage from "./TermDetailPage";
+import TermsConsentPage from "./TermsConsentPage";
 
 type OnboardingScreen =
   | "auth"
@@ -13,5 +19,18 @@ interface OnboardingPageProps {
 }
 
 export default function OnboardingPage({ screen }: OnboardingPageProps) {
-  return <PlaceholderScreen titleKey={`screens.onboarding.${screen}`} />;
+  switch (screen) {
+    case "auth":
+      return <AuthPage />;
+    case "termsConsent":
+      return <TermsConsentPage />;
+    case "termsDetail":
+      return <TermDetailPage />;
+    case "userPermission":
+      return <PermissionPage />;
+    case "locationPermissionGuide":
+      return <PermissionGuidePage kind="location" />;
+    case "batteryOptimizationGuide":
+      return <PermissionGuidePage kind="battery" />;
+  }
 }

--- a/web/src/pages/onboarding/PermissionGuidePage.tsx
+++ b/web/src/pages/onboarding/PermissionGuidePage.tsx
@@ -1,0 +1,53 @@
+import { useNavigate } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { Button } from "@/design-system";
+
+export default function PermissionGuidePage({
+  kind,
+}: {
+  kind: "location" | "battery";
+}) {
+  const bridge = useBridge();
+  const navigate = useNavigate();
+  const location = kind === "location";
+
+  async function openSettings() {
+    await bridge.requestPermission({
+      permission: location ? "locationAlways" : "batteryOptimization",
+    });
+  }
+
+  return (
+    <main className="onboarding">
+      <section className="onboarding__panel" aria-labelledby="guide-title">
+        <header className="onboarding__header">
+          <p className="onboarding__eyebrow">설정 안내</p>
+          <h1 id="guide-title">
+            {location
+              ? "위치를 항상 허용해 주세요"
+              : "배터리 제한을 해제해 주세요"}
+          </h1>
+          <p className="onboarding__description">
+            {location
+              ? "위치 권한을 ‘항상 허용’으로 선택하면 앱이 닫혀 있어도 도착을 감지할 수 있어요."
+              : "배터리 최적화 예외를 허용하면 백그라운드 자동 전송이 안정적으로 동작해요."}
+          </p>
+        </header>
+        <ol className="onboarding__list">
+          <li>아래 버튼을 눌러 시스템 설정을 열어 주세요.</li>
+          <li>
+            {location
+              ? "위치 권한에서 ‘항상 허용’을 선택해 주세요."
+              : "ImHere의 배터리 사용 제한을 해제해 주세요."}
+          </li>
+          <li>앱으로 돌아오면 상태를 자동으로 다시 확인해요.</li>
+        </ol>
+        <Button onClick={() => void openSettings()}>설정 열기</Button>
+        <Button variant="secondary" onClick={() => navigate(-1)}>
+          돌아가기
+        </Button>
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/onboarding/PermissionPage.tsx
+++ b/web/src/pages/onboarding/PermissionPage.tsx
@@ -1,0 +1,113 @@
+import type { NativeBridge } from "@imhere/bridge-contract";
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { Button, LoadingState } from "@/design-system";
+
+type Readiness = Awaited<ReturnType<NativeBridge["getAutoSendReadiness"]>>;
+
+const permissionCopy = {
+  locationAlways: ["항상 위치 허용", "앱이 닫혀 있어도 장소 도착을 감지해요."],
+  notification: ["알림 허용", "전송 결과와 도착 알림을 알려드려요."],
+  batteryOptimization: [
+    "배터리 최적화 예외",
+    "Android에서 자동 전송이 중단되지 않게 해요.",
+  ],
+} as const;
+
+export default function PermissionPage() {
+  const bridge = useBridge();
+  const navigate = useNavigate();
+  const [readiness, setReadiness] = useState<Readiness | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const value = await bridge.getAutoSendReadiness();
+      setReadiness(value);
+      if (value.ready) navigate("/geofence", { replace: true });
+    } catch {
+      setError("권한 상태를 확인하지 못했습니다.");
+    }
+  }, [bridge, navigate]);
+
+  useEffect(() => {
+    const initialRefresh = setTimeout(() => void refresh(), 0);
+    const unsubscribeResume = bridge.events.subscribe("onAppResumed", () => {
+      void refresh();
+    });
+    const unsubscribePermission = bridge.events.subscribe(
+      "onPermissionChanged",
+      () => void refresh(),
+    );
+    return () => {
+      clearTimeout(initialRefresh);
+      unsubscribeResume();
+      unsubscribePermission();
+    };
+  }, [bridge, refresh]);
+
+  async function request(permission: keyof typeof permissionCopy) {
+    await bridge.requestPermission({ permission });
+    await refresh();
+  }
+
+  return (
+    <main className="onboarding">
+      <section className="onboarding__panel" aria-labelledby="permission-title">
+        <header className="onboarding__header">
+          <p className="onboarding__eyebrow">자동 전송 준비</p>
+          <h1 id="permission-title">필요한 권한을 확인해 주세요</h1>
+          <p className="onboarding__description">
+            권한 요청은 앱에서만 처리되며 언제든 설정에서 바꿀 수 있어요.
+          </p>
+        </header>
+        {readiness === null && error === null ? (
+          <LoadingState label="권한 상태를 확인하는 중" />
+        ) : (
+          <div className="onboarding__list">
+            {Object.entries(permissionCopy).map(
+              ([permission, [title, description]]) => {
+                const complete =
+                  permission === "locationAlways"
+                    ? readiness?.locationAlways
+                    : permission === "notification"
+                      ? readiness?.notification
+                      : readiness?.batteryOptimization;
+                return (
+                  <article key={permission} className="onboarding__permission">
+                    <span aria-hidden="true">{complete ? "✓" : "○"}</span>
+                    <div>
+                      <strong>{title}</strong>
+                      <p className="onboarding__meta">{description}</p>
+                    </div>
+                    <Button
+                      variant={complete ? "ghost" : "secondary"}
+                      disabled={complete}
+                      onClick={() =>
+                        void request(permission as keyof typeof permissionCopy)
+                      }
+                    >
+                      {complete ? "완료" : "설정"}
+                    </Button>
+                  </article>
+                );
+              },
+            )}
+          </div>
+        )}
+        <div className="onboarding__permission-actions">
+          <Link to="/location-permission-guide">위치 권한 안내</Link>
+          <Link to="/battery-optimization-guide">배터리 설정 안내</Link>
+        </div>
+        <Button onClick={() => void refresh()}>상태 다시 확인</Button>
+        {error === null ? null : (
+          <p className="onboarding__error" role="alert">
+            {error}
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/onboarding/TermDetailPage.tsx
+++ b/web/src/pages/onboarding/TermDetailPage.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { Button, LoadingState } from "@/design-system";
+
+import { loadTerms, type Term } from "./terms-service";
+
+export default function TermDetailPage() {
+  const api = useApiClient();
+  const navigate = useNavigate();
+  const { termId } = useParams();
+  const [term, setTerm] = useState<Term | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadTerms(api, controller.signal)
+      .then((terms) => {
+        const found = terms.find((item) => String(item.id) === termId);
+        if (found === undefined) setError(true);
+        else setTerm(found);
+      })
+      .catch(() => setError(true));
+    return () => controller.abort();
+  }, [api, termId]);
+
+  return (
+    <main className="onboarding">
+      <article className="onboarding__panel" aria-labelledby="term-title">
+        {term === null && !error ? (
+          <LoadingState label="약관을 불러오는 중" />
+        ) : error ? (
+          <p className="onboarding__error" role="alert">
+            약관을 찾을 수 없습니다.
+          </p>
+        ) : (
+          <>
+            <header className="onboarding__header">
+              <h1 id="term-title">{term?.title}</h1>
+              <p className="onboarding__meta">시행일 {term?.effectiveDate}</p>
+            </header>
+            <div className="onboarding__content">{term?.content}</div>
+          </>
+        )}
+        <Button variant="secondary" onClick={() => navigate(-1)}>
+          돌아가기
+        </Button>
+      </article>
+    </main>
+  );
+}

--- a/web/src/pages/onboarding/TermsConsentPage.tsx
+++ b/web/src/pages/onboarding/TermsConsentPage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { Button, LoadingState } from "@/design-system";
+
+import { activateWithTerms, loadTerms, type Term } from "./terms-service";
+
+export default function TermsConsentPage() {
+  const api = useApiClient();
+  const navigate = useNavigate();
+  const [terms, setTerms] = useState<Term[] | null>(null);
+  const [agreed, setAgreed] = useState<Set<number>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requiredIds = useMemo(
+    () => terms?.filter((term) => term.isRequired).map((term) => term.id) ?? [],
+    [terms],
+  );
+  const allAgreed =
+    terms !== null && terms.length > 0 && agreed.size === terms.length;
+  const requiredAgreed = requiredIds.every((id) => agreed.has(id));
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadTerms(api, controller.signal)
+      .then(async (loaded) => {
+        setTerms(loaded);
+        if (loaded.length === 0) {
+          await activateWithTerms(api, []);
+          navigate("/user-permission", { replace: true });
+        }
+      })
+      .catch((reason: unknown) => {
+        if ((reason as { name?: string }).name !== "AbortError") {
+          setError("약관을 불러오지 못했습니다.");
+        }
+      });
+    return () => controller.abort();
+  }, [api, navigate]);
+
+  function toggle(id: number) {
+    setAgreed((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    if (terms === null || !requiredAgreed) return;
+    setSubmitting(true);
+    try {
+      await activateWithTerms(
+        api,
+        terms.filter((term) => agreed.has(term.id)),
+      );
+      navigate("/user-permission", { replace: true });
+    } catch {
+      setError("동의 내용을 저장하지 못했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="onboarding">
+      <section className="onboarding__panel" aria-labelledby="terms-title">
+        <header className="onboarding__header">
+          <p className="onboarding__eyebrow">약관 동의</p>
+          <h1 id="terms-title">ImHere 이용을 위해 확인해 주세요</h1>
+          <p className="onboarding__description">
+            선택 항목은 동의하지 않아도 서비스를 이용할 수 있어요.
+          </p>
+        </header>
+        {terms === null && error === null ? (
+          <LoadingState label="약관을 불러오는 중" />
+        ) : (
+          <div className="onboarding__list">
+            {terms !== null && terms.length > 0 ? (
+              <label className="onboarding__term">
+                <input
+                  type="checkbox"
+                  checked={allAgreed}
+                  onChange={() =>
+                    setAgreed(
+                      allAgreed
+                        ? new Set()
+                        : new Set(terms.map((term) => term.id)),
+                    )
+                  }
+                />
+                <strong>전체 동의</strong>
+              </label>
+            ) : null}
+            {terms?.map((term) => (
+              <label key={term.id} className="onboarding__term">
+                <input
+                  type="checkbox"
+                  checked={agreed.has(term.id)}
+                  onChange={() => toggle(term.id)}
+                />
+                <span>
+                  {term.isRequired ? "[필수]" : "[선택]"} {term.title}
+                </span>
+                <Link to={`/terms-detail/${term.id}`}>보기</Link>
+              </label>
+            ))}
+          </div>
+        )}
+        <Button
+          disabled={!requiredAgreed}
+          loading={submitting}
+          onClick={() => void submit()}
+        >
+          동의하고 계속하기
+        </Button>
+        {error === null ? null : (
+          <p className="onboarding__error" role="alert">
+            {error}
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/onboarding/TermsConsentPage.tsx
+++ b/web/src/pages/onboarding/TermsConsentPage.tsx
@@ -52,11 +52,7 @@ export default function TermsConsentPage() {
     if (terms === null || !requiredAgreed) return;
     setSubmitting(true);
     try {
-      await activateWithTerms(
-        api,
-        terms,
-        agreed,
-      );
+      await activateWithTerms(api, terms, agreed);
       navigate("/user-permission", { replace: true });
     } catch {
       setError("동의 내용을 저장하지 못했습니다.");

--- a/web/src/pages/onboarding/TermsConsentPage.tsx
+++ b/web/src/pages/onboarding/TermsConsentPage.tsx
@@ -54,7 +54,8 @@ export default function TermsConsentPage() {
     try {
       await activateWithTerms(
         api,
-        terms.filter((term) => agreed.has(term.id)),
+        terms,
+        agreed,
       );
       navigate("/user-permission", { replace: true });
     } catch {

--- a/web/src/pages/onboarding/onboarding.css
+++ b/web/src/pages/onboarding/onboarding.css
@@ -1,0 +1,85 @@
+.onboarding {
+  display: grid;
+  min-height: 100dvh;
+  place-items: center;
+  padding: var(--space-6);
+  color: var(--color-text);
+  background: var(--color-background);
+}
+
+.onboarding__panel {
+  display: grid;
+  width: min(100%, 34rem);
+  gap: var(--space-5);
+  padding: var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-xl);
+}
+
+.onboarding__header,
+.onboarding__actions,
+.onboarding__list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.onboarding__eyebrow,
+.onboarding__description,
+.onboarding__meta {
+  color: var(--color-text-secondary);
+}
+
+.onboarding__steps,
+.onboarding__permission-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.onboarding__step {
+  width: 0.6rem;
+  height: 0.6rem;
+  padding: 0;
+  background: var(--color-divider);
+  border: 0;
+  border-radius: var(--radius-pill);
+}
+
+.onboarding__step[aria-current="step"] {
+  width: 1.5rem;
+  background: var(--color-primary);
+}
+
+.onboarding__notice,
+.onboarding__error {
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+}
+
+.onboarding__notice {
+  background: var(--color-primary-soft);
+}
+
+.onboarding__error {
+  color: var(--color-error);
+  background: var(--color-error-soft);
+}
+
+.onboarding__term,
+.onboarding__permission {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  min-height: 52px;
+}
+
+.onboarding__term a {
+  color: var(--color-primary);
+}
+
+.onboarding__content {
+  line-height: 1.7;
+  white-space: pre-wrap;
+}

--- a/web/src/pages/onboarding/terms-service.test.ts
+++ b/web/src/pages/onboarding/terms-service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "@/api/api-client";
+
+import { activateWithTerms, type Term } from "./terms-service";
+
+const terms: Term[] = [
+  {
+    id: 1,
+    version: 3,
+    type: "SERVICE",
+    title: "필수 약관",
+    content: "내용",
+    effectiveDate: "2026-07-26",
+    isRequired: true,
+  },
+  {
+    id: 2,
+    version: 2,
+    type: "MARKETING",
+    title: "선택 약관",
+    content: "내용",
+    effectiveDate: "2026-07-26",
+    isRequired: false,
+  },
+];
+
+describe("activateWithTerms", () => {
+  it("matches the Flutter activation contract and includes declined terms", async () => {
+    const request = vi.fn().mockResolvedValue({});
+    const api = { request } as unknown as ApiClient;
+
+    await activateWithTerms(api, terms, new Set([1]));
+
+    expect(request).toHaveBeenCalledWith("/api/auth/activation", {
+      method: "POST",
+      body: JSON.stringify({
+        consents: [
+          { id: 1, agreed: true },
+          { id: 2, agreed: false },
+        ],
+      }),
+    });
+  });
+});

--- a/web/src/pages/onboarding/terms-service.ts
+++ b/web/src/pages/onboarding/terms-service.ts
@@ -14,14 +14,17 @@ export function loadTerms(api: ApiClient, signal?: AbortSignal) {
   return api.request<Term[]>("/api/terms?isActive=true", { signal });
 }
 
-export function activateWithTerms(api: ApiClient, terms: Term[]) {
+export function activateWithTerms(
+  api: ApiClient,
+  terms: Term[],
+  agreedIds?: ReadonlySet<number>,
+) {
   return api.request("/api/auth/activation", {
     method: "POST",
     body: JSON.stringify({
       consents: terms.map((term) => ({
-        termId: term.id,
-        termVersion: term.version,
-        agreed: true,
+        id: term.id,
+        agreed: agreedIds?.has(term.id) ?? true,
       })),
     }),
   });

--- a/web/src/pages/onboarding/terms-service.ts
+++ b/web/src/pages/onboarding/terms-service.ts
@@ -1,0 +1,28 @@
+import type { ApiClient } from "@/api/api-client";
+
+export interface Term {
+  content: string;
+  effectiveDate: string;
+  id: number;
+  isRequired: boolean;
+  title: string;
+  type: string;
+  version: number;
+}
+
+export function loadTerms(api: ApiClient, signal?: AbortSignal) {
+  return api.request<Term[]>("/api/terms?isActive=true", { signal });
+}
+
+export function activateWithTerms(api: ApiClient, terms: Term[]) {
+  return api.request("/api/auth/activation", {
+    method: "POST",
+    body: JSON.stringify({
+      consents: terms.map((term) => ({
+        termId: term.id,
+        termVersion: term.version,
+        agreed: true,
+      })),
+    }),
+  });
+}


### PR DESCRIPTION
## 연결 이슈

Closes #87

## 변경 목적

F08 인증·약관·권한 준비 화면을 실제 React 화면으로 구현합니다. PR #86 위의 stacked PR입니다.

## 대상 플랫폼

- [ ] Android
- [ ] iOS
- [x] Web
- [ ] 플랫폼 공통 또는 무관

## 주요 변경 사항

- 앱 JavaScriptChannel/브라우저 mock 공통 BridgeProvider
- `/auth` 3단계 안내, 카카오·Google 로그인, inactive/오류 안내
- `/terms-consent` 전체·개별 동의, 필수 검증, 빈 목록 자동 활성화
- `/terms-detail/:termId` 상세와 시행일
- `/user-permission` readiness, 앱 재개/권한 이벤트 재확인
- 위치·배터리 설정 가이드와 네이티브 브릿지 권한 요청
- 한국어 copy, 44px 이상 액션, semantic heading/fieldset/live error

## 완료 조건 확인

- [x] 로그인 3단계와 소셜 로그인
- [x] 약관 전체/개별/상세/빈 목록 자동 활성화
- [x] 권한 준비와 가이드 2종
- [x] 네이티브 기능은 브릿지만 사용
- [x] 접근성 자동 검사

## 검증

```text
pnpm format:check: 통과
pnpm lint: 통과
pnpm typecheck: 통과
pnpm test: 9 files / 43 tests 통과
pnpm build: 통과
pnpm bridge:check: 통과
axe-core auth 화면: violations 0
```

## UI 변경

인증·약관·권한의 7개 라우트가 placeholder에서 실제 화면으로 바뀝니다. 실제 카카오/Google SDK, OS 설정 복귀, 스크린리더는 앱 실기기 검토가 필요합니다.

## 위험 및 호환성

브라우저 개발에서는 전체 계약 mock을 사용하고 앱에서는 `window.ImHereBridge`만 사용합니다. refresh token은 웹 컨텍스트에 저장하지 않습니다.

## 최종 확인

- [x] 연결된 이슈의 구현 완료 조건을 충족했습니다.
- [x] 변경 범위에 맞는 테스트와 검증을 수행했습니다.
- [x] 대상 플랫폼별 영향을 확인했습니다.