### PR TITLE
feat(web): migrate geofence screens (F09)

### DIFF
--- a/lib/shell/bridge/generated/bridge_contract.generated.dart
+++ b/lib/shell/bridge/generated/bridge_contract.generated.dart
@@ -270,36 +270,48 @@ class GeofenceInput {
   const GeofenceInput({
     this.id,
     required this.name,
+    required this.address,
     required this.latitude,
     required this.longitude,
     required this.radiusMeters,
     required this.eventType,
+    required this.repeatType,
+    this.customDaysBitmask,
     required this.message,
     required this.active,
-    required this.recipientIds,
+    required this.deviceContactIds,
+    required this.serverRecipients,
   });
 
   final int? id;
   final String name;
+  final String address;
   final double latitude;
   final double longitude;
   final int radiusMeters;
   final GeofenceEventType eventType;
+  final RepeatType repeatType;
+  final int? customDaysBitmask;
   final String message;
   final bool active;
-  final List<int> recipientIds;
+  final List<String> deviceContactIds;
+  final List<ServerRecipient> serverRecipients;
 
   factory GeofenceInput.fromJson(Map<String, Object?> json) {
     return GeofenceInput(
       id: json['id'] == null ? null : (json['id'] as num).toInt(),
       name: json['name'] as String,
+      address: json['address'] as String,
       latitude: (json['latitude'] as num).toDouble(),
       longitude: (json['longitude'] as num).toDouble(),
       radiusMeters: (json['radiusMeters'] as num).toInt(),
       eventType: GeofenceEventType.values.byName(json['eventType'] as String),
+      repeatType: RepeatType.values.byName(json['repeatType'] as String),
+      customDaysBitmask: json['customDaysBitmask'] == null ? null : (json['customDaysBitmask'] as num).toInt(),
       message: json['message'] as String,
       active: json['active'] as bool,
-      recipientIds: (json['recipientIds'] as List<Object?>).map((item) => (item as num).toInt()).toList(),
+      deviceContactIds: (json['deviceContactIds'] as List<Object?>).map((item) => item as String).toList(),
+      serverRecipients: (json['serverRecipients'] as List<Object?>).map((item) => ServerRecipient.fromJson(item as Map<String, Object?>)).toList(),
     );
   }
 
@@ -307,13 +319,17 @@ class GeofenceInput {
     return <String, Object?>{
       if (id != null) 'id': id!,
       'name': name,
+      'address': address,
       'latitude': latitude,
       'longitude': longitude,
       'radiusMeters': radiusMeters,
       'eventType': eventType.name,
+      'repeatType': repeatType.name,
+      if (customDaysBitmask != null) 'customDaysBitmask': customDaysBitmask!,
       'message': message,
       'active': active,
-      'recipientIds': recipientIds.map((item) => item).toList(),
+      'deviceContactIds': deviceContactIds.map((item) => item).toList(),
+      'serverRecipients': serverRecipients.map((item) => item.toJson()).toList(),
     };
   }
 }
@@ -321,34 +337,79 @@ class GeofenceInput {
 enum GeofenceEventType {
   arrival,
   departure,
+  both,
+}
+
+enum RepeatType {
+  none,
+  daily,
+  weekday,
+  weekend,
+  custom,
+}
+
+class ServerRecipient {
+  const ServerRecipient({
+    required this.friendRelationshipId,
+    required this.friendEmail,
+    required this.friendAlias,
+  });
+
+  final String friendRelationshipId;
+  final String friendEmail;
+  final String friendAlias;
+
+  factory ServerRecipient.fromJson(Map<String, Object?> json) {
+    return ServerRecipient(
+      friendRelationshipId: json['friendRelationshipId'] as String,
+      friendEmail: json['friendEmail'] as String,
+      friendAlias: json['friendAlias'] as String,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'friendRelationshipId': friendRelationshipId,
+      'friendEmail': friendEmail,
+      'friendAlias': friendAlias,
+    };
+  }
 }
 
 class Geofence {
   const Geofence({
     required this.id,
     required this.name,
+    required this.address,
     required this.latitude,
     required this.longitude,
     required this.radiusMeters,
     required this.eventType,
+    required this.repeatType,
+    this.customDaysBitmask,
     required this.message,
     required this.active,
     required this.awaitingDeparture,
-    required this.recipientIds,
+    required this.deviceContactIds,
+    required this.serverRecipients,
     required this.createdAt,
     required this.updatedAt,
   });
 
   final int id;
   final String name;
+  final String address;
   final double latitude;
   final double longitude;
   final int radiusMeters;
   final GeofenceEventType eventType;
+  final RepeatType repeatType;
+  final int? customDaysBitmask;
   final String message;
   final bool active;
   final bool awaitingDeparture;
-  final List<int> recipientIds;
+  final List<String> deviceContactIds;
+  final List<ServerRecipient> serverRecipients;
   final String createdAt;
   final String updatedAt;
 
@@ -356,14 +417,18 @@ class Geofence {
     return Geofence(
       id: (json['id'] as num).toInt(),
       name: json['name'] as String,
+      address: json['address'] as String,
       latitude: (json['latitude'] as num).toDouble(),
       longitude: (json['longitude'] as num).toDouble(),
       radiusMeters: (json['radiusMeters'] as num).toInt(),
       eventType: GeofenceEventType.values.byName(json['eventType'] as String),
+      repeatType: RepeatType.values.byName(json['repeatType'] as String),
+      customDaysBitmask: json['customDaysBitmask'] == null ? null : (json['customDaysBitmask'] as num).toInt(),
       message: json['message'] as String,
       active: json['active'] as bool,
       awaitingDeparture: json['awaitingDeparture'] as bool,
-      recipientIds: (json['recipientIds'] as List<Object?>).map((item) => (item as num).toInt()).toList(),
+      deviceContactIds: (json['deviceContactIds'] as List<Object?>).map((item) => item as String).toList(),
+      serverRecipients: (json['serverRecipients'] as List<Object?>).map((item) => ServerRecipient.fromJson(item as Map<String, Object?>)).toList(),
       createdAt: json['createdAt'] as String,
       updatedAt: json['updatedAt'] as String,
     );
@@ -373,14 +438,18 @@ class Geofence {
     return <String, Object?>{
       'id': id,
       'name': name,
+      'address': address,
       'latitude': latitude,
       'longitude': longitude,
       'radiusMeters': radiusMeters,
       'eventType': eventType.name,
+      'repeatType': repeatType.name,
+      if (customDaysBitmask != null) 'customDaysBitmask': customDaysBitmask!,
       'message': message,
       'active': active,
       'awaitingDeparture': awaitingDeparture,
-      'recipientIds': recipientIds.map((item) => item).toList(),
+      'deviceContactIds': deviceContactIds.map((item) => item).toList(),
+      'serverRecipients': serverRecipients.map((item) => item.toJson()).toList(),
       'createdAt': createdAt,
       'updatedAt': updatedAt,
     };

--- a/web/packages/bridge-contract/src/bridge.test.ts
+++ b/web/packages/bridge-contract/src/bridge.test.ts
@@ -49,6 +49,14 @@ describe("bridge contract", () => {
         | "locationWhenInUse"
         | "notification";
     }>();
+    expectTypeOf<
+      Parameters<BridgeApi["registerGeofence"]>[0]
+    >().toMatchObjectType<{
+      address: string;
+      eventType: "arrival" | "both" | "departure";
+      repeatType: "custom" | "daily" | "none" | "weekday" | "weekend";
+      deviceContactIds: string[];
+    }>();
   });
 });
 

--- a/web/packages/bridge-contract/src/contract.ts
+++ b/web/packages/bridge-contract/src/contract.ts
@@ -36,6 +36,14 @@ export const PermissionStatus = s.enum("PermissionStatus", [
 export const GeofenceEventType = s.enum("GeofenceEventType", [
   "arrival",
   "departure",
+  "both",
+] as const);
+export const RepeatType = s.enum("RepeatType", [
+  "none",
+  "daily",
+  "weekday",
+  "weekend",
+  "custom",
 ] as const);
 export const ConnectivityType = s.enum("ConnectivityType", [
   "wifi",
@@ -105,29 +113,43 @@ export const AutoSendReadiness = s.object("AutoSendReadiness", {
   missing: s.array(PermissionType),
 });
 
+export const ServerRecipient = s.object("ServerRecipient", {
+  friendRelationshipId: s.string,
+  friendEmail: s.string,
+  friendAlias: s.string,
+});
+
 export const GeofenceInput = s.object("GeofenceInput", {
   id: s.optional(s.integer),
   name: s.string,
+  address: s.string,
   latitude: s.number,
   longitude: s.number,
   radiusMeters: s.integer,
   eventType: GeofenceEventType,
+  repeatType: RepeatType,
+  customDaysBitmask: s.optional(s.integer),
   message: s.string,
   active: s.boolean,
-  recipientIds: s.array(s.integer),
+  deviceContactIds: s.array(s.string),
+  serverRecipients: s.array(ServerRecipient),
 });
 
 export const Geofence = s.object("Geofence", {
   id: s.integer,
   name: s.string,
+  address: s.string,
   latitude: s.number,
   longitude: s.number,
   radiusMeters: s.integer,
   eventType: GeofenceEventType,
+  repeatType: RepeatType,
+  customDaysBitmask: s.optional(s.integer),
   message: s.string,
   active: s.boolean,
   awaitingDeparture: s.boolean,
-  recipientIds: s.array(s.integer),
+  deviceContactIds: s.array(s.string),
+  serverRecipients: s.array(ServerRecipient),
   createdAt: s.string,
   updatedAt: s.string,
 });

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -68,6 +68,10 @@ export const appRoutes: RouteObject[] = [
             element: <GeofencePage screen="message" />,
           },
           {
+            path: "geofence/:geofenceId/edit",
+            element: <GeofencePage screen="edit" />,
+          },
+          {
             path: "friend",
             element: <FriendPage screen="list" />,
           },

--- a/web/src/locales/ko/translation.json
+++ b/web/src/locales/ko/translation.json
@@ -1,6 +1,15 @@
 {
   "common": {
     "loading": "화면을 불러오는 중입니다.",
+    "loadingShort": "확인 중",
+    "enabled": "켜짐",
+    "disabled": "꺼짐",
+    "retry": "다시 시도",
+    "edit": "수정",
+    "delete": "삭제",
+    "cancel": "취소",
+    "confirm": "확인",
+    "backToList": "목록으로",
     "placeholder": {
       "eyebrow": "React 전환 준비",
       "description": "이 경로의 실제 화면은 후속 Feature에서 구현합니다."
@@ -22,6 +31,75 @@
     "add": "알림 장소 추가",
     "record": "기록",
     "setting": "설정"
+  },
+  "geofence": {
+    "event": {
+      "arrival": "도착",
+      "departure": "출발",
+      "both": "도착·출발 모두"
+    },
+    "repeat": {
+      "none": "반복 안 함",
+      "daily": "매일",
+      "weekday": "평일",
+      "weekend": "주말",
+      "custom": "직접 설정"
+    },
+    "weekday": {
+      "0": "일",
+      "1": "월",
+      "2": "화",
+      "3": "수",
+      "4": "목",
+      "5": "금",
+      "6": "토"
+    },
+    "recipient": {
+      "device": "기기 연락처",
+      "server": "ImHere 친구"
+    },
+    "list": {
+      "eyebrow": "자동 위치 알림",
+      "title": "알림 장소",
+      "description": "장소에 도착하거나 출발할 때 선택한 사람에게 알려요.",
+      "add": "장소 추가",
+      "locationService": "GPS 상태",
+      "autoSend": "자동 전송 준비",
+      "ready": "준비 완료",
+      "needsSetup": "{{count}}개 설정 필요",
+      "permissionWarning": "백그라운드 자동 전송을 위해 권한 설정이 필요합니다.",
+      "openPermission": "설정 확인",
+      "loadError": "알림 장소를 불러오지 못했습니다.",
+      "loading": "알림 장소를 불러오는 중",
+      "emptyTitle": "등록한 알림 장소가 없어요",
+      "emptyDescription": "첫 장소를 등록하면 앱이 꺼져 있어도 출입을 감지할 수 있어요.",
+      "awaitingDeparture": "도착 알림을 보냈어요. 다음 출발을 기다리는 중입니다.",
+      "deleteTitle": "알림 장소를 삭제할까요?",
+      "deleteDescription": "‘{{name}}’의 네이티브 지오펜스도 함께 해제됩니다."
+    },
+    "form": {
+      "eyebrow": "알림 장소 설정",
+      "createTitle": "새 알림 장소",
+      "editTitle": "알림 장소 수정",
+      "loading": "알림 장소 폼을 준비하는 중",
+      "notFound": "수정할 알림 장소를 찾지 못했습니다.",
+      "loadError": "알림 장소 정보를 준비하지 못했습니다.",
+      "location": "장소와 반경",
+      "details": "이름과 메시지",
+      "name": "장소 이름",
+      "address": "주소",
+      "message": "알림 메시지",
+      "event": "언제 알릴까요?",
+      "repeat": "반복 설정",
+      "recipients": "받는 사람",
+      "recipientDescription": "ImHere 친구와 기기 연락처를 함께 선택할 수 있어요.",
+      "activateImmediately": "저장 후 바로 활성화",
+      "create": "알림 장소 만들기",
+      "save": "변경사항 저장",
+      "saveError": "알림 장소를 저장하지 못했습니다.",
+      "completeTitle": "알림 장소를 저장했어요",
+      "completeDescription": "‘{{name}}’ 출입을 네이티브에서 감지합니다."
+    }
   },
   "screens": {
     "onboarding": {

--- a/web/src/pages/feature-page.css
+++ b/web/src/pages/feature-page.css
@@ -1,0 +1,268 @@
+.feature-page {
+  display: grid;
+  gap: var(--space-5);
+  width: 100%;
+  padding: var(--space-6) var(--space-6) var(--space-12);
+}
+
+.feature-page__header,
+.feature-page__row,
+.feature-page__section-header {
+  display: flex;
+  gap: var(--space-4);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.feature-page__header {
+  align-items: flex-start;
+}
+
+.feature-page__header h1,
+.feature-page__section-header h2 {
+  margin: 0;
+  font-family: var(--font-title);
+  letter-spacing: -0.045em;
+}
+
+.feature-page__header h1 {
+  font-size: var(--text-headline-large);
+}
+
+.feature-page__header p,
+.feature-page__section-header p {
+  margin: var(--space-2) 0 0;
+  color: var(--color-text-secondary);
+  line-height: var(--line-body-large);
+}
+
+.feature-page__eyebrow {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--color-primary);
+  font-size: var(--text-body-medium);
+  font-weight: 750;
+}
+
+.feature-page__back {
+  display: inline-flex;
+  min-height: var(--touch-target-min);
+  align-items: center;
+  color: var(--color-primary);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.feature-page__grid,
+.feature-page__status-grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.feature-page__status-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.feature-page__status-card {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.feature-page__status-card span {
+  color: var(--color-text-secondary);
+  font-size: var(--text-body-small);
+}
+
+.feature-page__status-card strong {
+  color: var(--color-text);
+}
+
+.feature-page__banner {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  background: var(--color-primary-soft);
+  line-height: var(--line-body-medium);
+}
+
+.feature-page__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.feature-page__actions > * {
+  flex: 1 1 8rem;
+}
+
+.feature-page__list {
+  display: grid;
+  gap: var(--space-3);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.feature-page__list-card {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+}
+
+.feature-page__list-card h2,
+.feature-page__list-card h3 {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.feature-page__list-card p {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.feature-page__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.feature-page__chip {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  font-size: var(--text-body-small);
+  font-weight: 700;
+}
+
+.feature-page__switch {
+  display: inline-flex;
+  min-height: var(--touch-target-min);
+  gap: var(--space-2);
+  align-items: center;
+  cursor: pointer;
+}
+
+.feature-page__switch input {
+  width: 1.25rem;
+  height: 1.25rem;
+  accent-color: var(--color-primary);
+}
+
+.feature-page__error {
+  margin: 0;
+  color: var(--color-danger);
+}
+
+.feature-form {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.feature-form__section {
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.feature-form__section h2,
+.feature-form__section legend {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--text-headline-small);
+  font-weight: 750;
+}
+
+.feature-form__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 0;
+  border: 0;
+}
+
+.feature-form__option {
+  display: inline-flex;
+  min-height: var(--touch-target-min);
+  gap: var(--space-2);
+  align-items: center;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+
+.feature-form__option:has(input:checked) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.feature-form__recipients {
+  display: grid;
+  max-height: 20rem;
+  gap: var(--space-2);
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.feature-form__recipient {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-3);
+  align-items: center;
+  min-height: var(--touch-target-min);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-raised);
+  cursor: pointer;
+}
+
+.feature-form__recipient span {
+  display: grid;
+}
+
+.feature-form__recipient small {
+  color: var(--color-text-secondary);
+}
+
+@media (min-width: 52rem) {
+  .feature-page__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .feature-page__grid > .feature-page__section-header,
+  .feature-page__grid > .ds-empty-state {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 40rem) {
+  .feature-page {
+    padding: var(--space-4) var(--space-5) var(--space-10);
+  }
+
+  .feature-page__header h1 {
+    font-size: 2rem;
+  }
+
+  .feature-page__status-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/pages/geofence/GeofenceFormScreen.tsx
+++ b/web/src/pages/geofence/GeofenceFormScreen.tsx
@@ -1,0 +1,370 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { useBridge } from "@/bridge/bridge-context";
+import { BottomSheet, Button, LoadingState, TextField } from "@/design-system";
+import { MapProxyService } from "@/map/map-proxy-service";
+import {
+  NaverLocationPicker,
+  type MapSelection,
+} from "@/map/NaverLocationPicker";
+
+import {
+  defaultGeofenceDraft,
+  draftFromGeofence,
+  type EventType,
+  type GeofenceDraft,
+  type RecipientOption,
+  type RepeatType,
+  toBridgeInput,
+  validateGeofenceDraft,
+} from "./geofence-model";
+import { findGeofence, loadRecipientOptions } from "./geofence-service";
+
+const eventTypes: EventType[] = ["arrival", "departure", "both"];
+const repeatTypes: RepeatType[] = [
+  "none",
+  "daily",
+  "weekday",
+  "weekend",
+  "custom",
+];
+const weekDays = [0, 1, 2, 3, 4, 5, 6];
+
+export function GeofenceFormScreen({ id }: { id?: number }) {
+  const { t } = useTranslation();
+  const bridge = useBridge();
+  const api = useApiClient();
+  const navigate = useNavigate();
+  const mapService = useMemo(() => new MapProxyService(api), [api]);
+  const [draft, setDraft] = useState<GeofenceDraft | null>(null);
+  const [recipients, setRecipients] = useState<RecipientOption[]>([]);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      loadRecipientOptions(api, bridge),
+      id === undefined ? bridge.getCurrentPosition() : findGeofence(bridge, id),
+    ])
+      .then(([options, source]) => {
+        if (cancelled) return;
+        setRecipients(options);
+        if (id === undefined) {
+          const position = source as Awaited<
+            ReturnType<typeof bridge.getCurrentPosition>
+          >;
+          setDraft({
+            ...defaultGeofenceDraft,
+            latitude: position.latitude,
+            longitude: position.longitude,
+          });
+        } else if (source !== undefined && "radiusMeters" in source) {
+          setDraft(draftFromGeofence(source));
+        } else {
+          setLoadError(t("geofence.form.notFound"));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(t("geofence.form.loadError"));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, bridge, id, t]);
+
+  const update = useCallback(
+    <Key extends keyof GeofenceDraft>(key: Key, value: GeofenceDraft[Key]) => {
+      setDraft((current) =>
+        current === null ? current : { ...current, [key]: value },
+      );
+      setErrors((current) => ({ ...current, [key]: "" }));
+    },
+    [],
+  );
+
+  function updateMap(selection: MapSelection) {
+    setDraft((current) =>
+      current === null
+        ? current
+        : {
+            ...current,
+            address: selection.address ?? current.address,
+            latitude: selection.latitude,
+            longitude: selection.longitude,
+            radiusMeters: selection.radiusMeters,
+          },
+    );
+  }
+
+  function toggleRecipient(option: RecipientOption) {
+    if (draft === null) return;
+    if (option.source === "device") {
+      const next = new Set(draft.deviceContactIds);
+      if (next.has(option.key)) next.delete(option.key);
+      else next.add(option.key);
+      update("deviceContactIds", next);
+    } else {
+      const next = new Set(draft.serverRecipientKeys);
+      if (next.has(option.key)) next.delete(option.key);
+      else next.add(option.key);
+      update("serverRecipientKeys", next);
+    }
+    setErrors((current) => ({ ...current, recipients: "" }));
+  }
+
+  function toggleDay(day: number) {
+    if (draft === null) return;
+    const next = new Set(draft.customDays);
+    if (next.has(day)) next.delete(day);
+    else next.add(day);
+    update("customDays", next);
+  }
+
+  async function submit() {
+    if (draft === null) return;
+    const nextErrors = validateGeofenceDraft(draft);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    setSaving(true);
+    try {
+      await bridge.registerGeofence(toBridgeInput(draft, recipients));
+      setSaved(true);
+    } catch {
+      setErrors({ submit: t("geofence.form.saveError") });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loadError !== null) {
+    return (
+      <section className="feature-page">
+        <p className="feature-page__error" role="alert">
+          {loadError}
+        </p>
+        <Link className="feature-page__back" to="/geofence">
+          {t("common.backToList")}
+        </Link>
+      </section>
+    );
+  }
+  if (draft === null) {
+    return (
+      <section className="feature-page">
+        <LoadingState label={t("geofence.form.loading")} rows={5} />
+      </section>
+    );
+  }
+
+  const selection: MapSelection = {
+    address: draft.address,
+    latitude: draft.latitude,
+    longitude: draft.longitude,
+    radiusMeters: draft.radiusMeters,
+  };
+
+  return (
+    <section className="feature-page" aria-labelledby="geofence-form-title">
+      <header className="feature-page__header">
+        <div>
+          <Link className="feature-page__back" to="/geofence">
+            ← {t("common.backToList")}
+          </Link>
+          <span className="feature-page__eyebrow">
+            {t("geofence.form.eyebrow")}
+          </span>
+          <h1 id="geofence-form-title">
+            {id === undefined
+              ? t("geofence.form.createTitle")
+              : t("geofence.form.editTitle")}
+          </h1>
+        </div>
+      </header>
+
+      <form
+        className="feature-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+      >
+        <section className="feature-form__section">
+          <h2>{t("geofence.form.location")}</h2>
+          <NaverLocationPicker
+            clientId={import.meta.env.VITE_NAVER_MAP_CLIENT_ID || "browser"}
+            value={selection}
+            onChange={updateMap}
+            searchPlaces={(query, signal) =>
+              mapService.searchPlaces(query, signal)
+            }
+          />
+          {errors.address === undefined ||
+          errors.address.length === 0 ? null : (
+            <p className="feature-page__error" role="alert">
+              {errors.address}
+            </p>
+          )}
+        </section>
+
+        <section className="feature-form__section">
+          <h2>{t("geofence.form.details")}</h2>
+          <TextField
+            label={t("geofence.form.name")}
+            value={draft.name}
+            error={errors.name || undefined}
+            onChange={(event) => update("name", event.target.value)}
+          />
+          <TextField
+            label={t("geofence.form.address")}
+            value={draft.address}
+            readOnly
+            error={errors.address || undefined}
+          />
+          <TextField
+            label={t("geofence.form.message")}
+            value={draft.message}
+            error={errors.message || undefined}
+            onChange={(event) => update("message", event.target.value)}
+          />
+        </section>
+
+        <fieldset className="feature-form__section">
+          <legend>{t("geofence.form.event")}</legend>
+          <div className="feature-form__options">
+            {eventTypes.map((eventType) => (
+              <label className="feature-form__option" key={eventType}>
+                <input
+                  type="radio"
+                  name="eventType"
+                  value={eventType}
+                  checked={draft.eventType === eventType}
+                  onChange={() => update("eventType", eventType)}
+                />
+                {t(`geofence.event.${eventType}`)}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="feature-form__section">
+          <legend>{t("geofence.form.repeat")}</legend>
+          <div className="feature-form__options">
+            {repeatTypes.map((repeatType) => (
+              <label className="feature-form__option" key={repeatType}>
+                <input
+                  type="radio"
+                  name="repeatType"
+                  value={repeatType}
+                  checked={draft.repeatType === repeatType}
+                  onChange={() => update("repeatType", repeatType)}
+                />
+                {t(`geofence.repeat.${repeatType}`)}
+              </label>
+            ))}
+          </div>
+          {draft.repeatType === "custom" ? (
+            <div className="feature-form__options">
+              {weekDays.map((day) => (
+                <label className="feature-form__option" key={day}>
+                  <input
+                    type="checkbox"
+                    checked={draft.customDays.has(day)}
+                    onChange={() => toggleDay(day)}
+                  />
+                  {t(`geofence.weekday.${day}`)}
+                </label>
+              ))}
+            </div>
+          ) : null}
+          {errors.customDays === undefined ||
+          errors.customDays.length === 0 ? null : (
+            <p className="feature-page__error" role="alert">
+              {errors.customDays}
+            </p>
+          )}
+        </fieldset>
+
+        <section className="feature-form__section">
+          <div className="feature-page__section-header">
+            <div>
+              <h2>{t("geofence.form.recipients")}</h2>
+              <p>{t("geofence.form.recipientDescription")}</p>
+            </div>
+            <span className="feature-page__chip">
+              {draft.deviceContactIds.size + draft.serverRecipientKeys.size}
+            </span>
+          </div>
+          <ul className="feature-form__recipients">
+            {recipients.map((recipient) => {
+              const checked =
+                recipient.source === "device"
+                  ? draft.deviceContactIds.has(recipient.key)
+                  : draft.serverRecipientKeys.has(recipient.key);
+              return (
+                <li key={`${recipient.source}:${recipient.key}`}>
+                  <label className="feature-form__recipient">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleRecipient(recipient)}
+                    />
+                    <span>
+                      <strong>{recipient.label}</strong>
+                      <small>
+                        {recipient.description} ·{" "}
+                        {t(`geofence.recipient.${recipient.source}`)}
+                      </small>
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+          {errors.recipients === undefined ||
+          errors.recipients.length === 0 ? null : (
+            <p className="feature-page__error" role="alert">
+              {errors.recipients}
+            </p>
+          )}
+        </section>
+
+        <label className="feature-page__switch">
+          <input
+            type="checkbox"
+            checked={draft.active}
+            onChange={(event) => update("active", event.target.checked)}
+          />
+          <span>{t("geofence.form.activateImmediately")}</span>
+        </label>
+
+        {errors.submit === undefined ? null : (
+          <p className="feature-page__error" role="alert">
+            {errors.submit}
+          </p>
+        )}
+        <Button loading={saving} type="submit">
+          {id === undefined
+            ? t("geofence.form.create")
+            : t("geofence.form.save")}
+        </Button>
+      </form>
+
+      <BottomSheet
+        open={saved}
+        title={t("geofence.form.completeTitle")}
+        onClose={() => navigate("/geofence")}
+      >
+        <p>{t("geofence.form.completeDescription", { name: draft.name })}</p>
+        <Button onClick={() => navigate("/geofence")}>
+          {t("common.confirm")}
+        </Button>
+      </BottomSheet>
+    </section>
+  );
+}

--- a/web/src/pages/geofence/GeofenceListScreen.tsx
+++ b/web/src/pages/geofence/GeofenceListScreen.tsx
@@ -1,0 +1,210 @@
+import type { BridgeMethodResult } from "@imhere/bridge-contract";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { BottomSheet, Button, EmptyState, LoadingState } from "@/design-system";
+
+import type { Geofence } from "./geofence-model";
+import { loadGeofences } from "./geofence-service";
+
+export function GeofenceListScreen() {
+  const { t } = useTranslation();
+  const bridge = useBridge();
+  const navigate = useNavigate();
+  const [items, setItems] = useState<Geofence[] | null>(null);
+  const [readiness, setReadiness] =
+    useState<BridgeMethodResult<"getAutoSendReadiness"> | null>(null);
+  const [locationEnabled, setLocationEnabled] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Geofence | null>(null);
+
+  const load = useCallback(async () => {
+    const [geofences, autoSend, location] = await Promise.allSettled([
+      loadGeofences(bridge),
+      bridge.getAutoSendReadiness(),
+      bridge.getLocationServiceStatus(),
+    ]);
+    if (geofences.status === "fulfilled") {
+      setItems(geofences.value);
+      setError(null);
+    } else {
+      setItems([]);
+      setError(t("geofence.list.loadError"));
+    }
+    if (autoSend.status === "fulfilled") setReadiness(autoSend.value);
+    if (location.status === "fulfilled") {
+      setLocationEnabled(location.value.status === "enabled");
+    }
+  }, [bridge, t]);
+
+  useEffect(() => {
+    const initialLoad = globalThis.setTimeout(() => void load(), 0);
+    const unsubscribe = bridge.events.subscribe(
+      "onAppResumed",
+      () => void load(),
+    );
+    return () => {
+      globalThis.clearTimeout(initialLoad);
+      unsubscribe();
+    };
+  }, [bridge, load]);
+
+  async function toggleActive(item: Geofence, active: boolean) {
+    const updated = await bridge.setGeofenceActive({ id: item.id, active });
+    setItems(
+      (current) =>
+        current?.map((value) => (value.id === updated.id ? updated : value)) ??
+        [],
+    );
+  }
+
+  async function remove() {
+    if (deleteTarget === null) return;
+    await bridge.unregisterGeofence({ id: deleteTarget.id });
+    setItems(
+      (current) => current?.filter((item) => item.id !== deleteTarget.id) ?? [],
+    );
+    setDeleteTarget(null);
+  }
+
+  return (
+    <section className="feature-page" aria-labelledby="geofence-list-title">
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">
+            {t("geofence.list.eyebrow")}
+          </span>
+          <h1 id="geofence-list-title">{t("geofence.list.title")}</h1>
+          <p>{t("geofence.list.description")}</p>
+        </div>
+        <Button onClick={() => navigate("/geofence/message")}>
+          {t("geofence.list.add")}
+        </Button>
+      </header>
+
+      <div className="feature-page__status-grid">
+        <div className="feature-page__status-card">
+          <span>{t("geofence.list.locationService")}</span>
+          <strong>
+            {locationEnabled === null
+              ? t("common.loadingShort")
+              : locationEnabled
+                ? t("common.enabled")
+                : t("common.disabled")}
+          </strong>
+        </div>
+        <div className="feature-page__status-card">
+          <span>{t("geofence.list.autoSend")}</span>
+          <strong>
+            {readiness === null
+              ? t("common.loadingShort")
+              : readiness.ready
+                ? t("geofence.list.ready")
+                : t("geofence.list.needsSetup", {
+                    count: readiness.missing.length,
+                  })}
+          </strong>
+        </div>
+      </div>
+
+      {readiness !== null && !readiness.ready ? (
+        <div className="feature-page__banner" role="status">
+          {t("geofence.list.permissionWarning")}{" "}
+          <Link to="/user-permission">{t("geofence.list.openPermission")}</Link>
+        </div>
+      ) : null}
+      {error === null ? null : (
+        <p className="feature-page__error" role="alert">
+          {error}{" "}
+          <button onClick={() => void load()}>{t("common.retry")}</button>
+        </p>
+      )}
+
+      {items === null ? (
+        <LoadingState label={t("geofence.list.loading")} rows={3} />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon="◎"
+          title={t("geofence.list.emptyTitle")}
+          description={t("geofence.list.emptyDescription")}
+          actionLabel={t("geofence.list.add")}
+          onAction={() => navigate("/geofence/message")}
+        />
+      ) : (
+        <ul className="feature-page__list">
+          {items.map((item) => (
+            <li className="feature-page__list-card" key={item.id}>
+              <div className="feature-page__row">
+                <div>
+                  <h2>{item.name}</h2>
+                  <p>{item.address}</p>
+                </div>
+                <label className="feature-page__switch">
+                  <input
+                    type="checkbox"
+                    checked={item.active}
+                    onChange={(event) =>
+                      void toggleActive(item, event.target.checked)
+                    }
+                  />
+                  <span>
+                    {item.active ? t("common.enabled") : t("common.disabled")}
+                  </span>
+                </label>
+              </div>
+              <div className="feature-page__meta">
+                <span className="feature-page__chip">
+                  {t(`geofence.event.${item.eventType}`)}
+                </span>
+                <span className="feature-page__chip">
+                  {item.radiusMeters === 1000 ? "1km" : `${item.radiusMeters}m`}
+                </span>
+                <span className="feature-page__chip">
+                  {t(`geofence.repeat.${item.repeatType}`)}
+                </span>
+              </div>
+              {item.awaitingDeparture ? (
+                <div className="feature-page__banner">
+                  {t("geofence.list.awaitingDeparture")}
+                </div>
+              ) : null}
+              <div className="feature-page__actions">
+                <Button
+                  variant="secondary"
+                  onClick={() => navigate(`/geofence/${item.id}/edit`)}
+                >
+                  {t("common.edit")}
+                </Button>
+                <Button variant="danger" onClick={() => setDeleteTarget(item)}>
+                  {t("common.delete")}
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <BottomSheet
+        open={deleteTarget !== null}
+        title={t("geofence.list.deleteTitle")}
+        onClose={() => setDeleteTarget(null)}
+      >
+        <p>
+          {t("geofence.list.deleteDescription", {
+            name: deleteTarget?.name ?? "",
+          })}
+        </p>
+        <div className="feature-page__actions">
+          <Button variant="secondary" onClick={() => setDeleteTarget(null)}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="danger" onClick={() => void remove()}>
+            {t("common.delete")}
+          </Button>
+        </div>
+      </BottomSheet>
+    </section>
+  );
+}

--- a/web/src/pages/geofence/GeofencePage.test.tsx
+++ b/web/src/pages/geofence/GeofencePage.test.tsx
@@ -1,0 +1,79 @@
+import { createMockBridge } from "@imhere/bridge-contract";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import axe from "axe-core";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { BridgeProvider } from "@/bridge/BridgeProvider";
+
+import GeofencePage from "./GeofencePage";
+
+const geofence = {
+  id: 7,
+  name: "회사",
+  address: "서울시 중구 세종대로",
+  latitude: 37.5665,
+  longitude: 126.978,
+  radiusMeters: 500,
+  eventType: "both" as const,
+  repeatType: "weekday" as const,
+  message: "회사에 도착했습니다.",
+  active: true,
+  awaitingDeparture: false,
+  deviceContactIds: [],
+  serverRecipients: [],
+  createdAt: "2026-07-26T00:00:00Z",
+  updatedAt: "2026-07-26T00:00:00Z",
+};
+
+function renderList() {
+  const controller = createMockBridge({
+    queryGeofences: async () => ({ items: [geofence] }),
+    getAutoSendReadiness: async () => ({
+      ready: true,
+      locationAlways: true,
+      locationService: true,
+      notification: true,
+      batteryOptimization: true,
+      missing: [],
+    }),
+    getLocationServiceStatus: async () => ({ status: "enabled" }),
+    setGeofenceActive: async (value) => ({
+      ...geofence,
+      active: (value as { active: boolean }).active,
+    }),
+  });
+  const view = render(
+    <BridgeProvider bridge={controller.bridge}>
+      <MemoryRouter>
+        <GeofencePage screen="list" />
+      </MemoryRouter>
+    </BridgeProvider>,
+  );
+  return { controller, ...view };
+}
+
+describe("GeofencePage", () => {
+  it("renders native geofences and updates the active state through the bridge", async () => {
+    const { controller } = renderList();
+    expect(await screen.findByRole("heading", { name: "회사" })).toBeVisible();
+    expect(screen.getByText("도착·출발 모두")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() =>
+      expect(
+        controller.calls.some(
+          (call) =>
+            call.method === "setGeofenceActive" &&
+            (call.args[0] as { active: boolean }).active === false,
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("has no automated accessibility violations", async () => {
+    const { container } = renderList();
+    await screen.findByRole("heading", { name: "회사" });
+    expect((await axe.run(container)).violations).toEqual([]);
+  });
+});

--- a/web/src/pages/geofence/GeofencePage.tsx
+++ b/web/src/pages/geofence/GeofencePage.tsx
@@ -1,9 +1,19 @@
-import { PlaceholderScreen } from "@/components/PlaceholderScreen";
+import { useParams } from "react-router-dom";
 
 interface GeofencePageProps {
-  screen: "list" | "message";
+  screen: "edit" | "list" | "message";
 }
 
 export default function GeofencePage({ screen }: GeofencePageProps) {
-  return <PlaceholderScreen titleKey={`screens.geofence.${screen}`} />;
+  const { geofenceId } = useParams();
+  if (screen === "list") return <GeofenceListScreen />;
+  return (
+    <GeofenceFormScreen
+      id={screen === "edit" ? Number(geofenceId) : undefined}
+    />
+  );
 }
+
+import { GeofenceFormScreen } from "./GeofenceFormScreen";
+import { GeofenceListScreen } from "./GeofenceListScreen";
+import "../feature-page.css";

--- a/web/src/pages/geofence/geofence-model.test.ts
+++ b/web/src/pages/geofence/geofence-model.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bitmaskFromDays,
+  defaultGeofenceDraft,
+  daysFromBitmask,
+  toBridgeInput,
+  type RecipientOption,
+} from "./geofence-model";
+
+const recipients: RecipientOption[] = [
+  {
+    key: "friendship-1",
+    label: "민지",
+    description: "minji@example.com",
+    source: "server",
+    value: {
+      friendRelationshipId: "friendship-1",
+      friendEmail: "minji@example.com",
+      friendAlias: "민지",
+    },
+  },
+  {
+    key: "contact-1",
+    label: "가족",
+    description: "010-1234-5678",
+    source: "device",
+    value: "contact-1",
+  },
+];
+
+describe("geofence model", () => {
+  it("round-trips a custom weekday bitmask", () => {
+    const days = new Set([1, 3, 5]);
+    expect(daysFromBitmask(bitmaskFromDays(days))).toEqual(days);
+  });
+
+  it("builds the native payload with both recipient sources", () => {
+    const payload = toBridgeInput(
+      {
+        ...defaultGeofenceDraft,
+        name: "회사",
+        address: "서울시 중구",
+        eventType: "both",
+        repeatType: "custom",
+        customDays: new Set([1, 2, 3, 4, 5]),
+        deviceContactIds: new Set(["contact-1"]),
+        serverRecipientKeys: new Set(["friendship-1"]),
+      },
+      recipients,
+    );
+
+    expect(payload).toMatchObject({
+      name: "회사",
+      address: "서울시 중구",
+      eventType: "both",
+      repeatType: "custom",
+      customDaysBitmask: 62,
+      deviceContactIds: ["contact-1"],
+      serverRecipients: [
+        {
+          friendRelationshipId: "friendship-1",
+          friendEmail: "minji@example.com",
+        },
+      ],
+    });
+  });
+});

--- a/web/src/pages/geofence/geofence-model.ts
+++ b/web/src/pages/geofence/geofence-model.ts
@@ -1,0 +1,131 @@
+import type { BridgeMethodResult, NativeBridge } from "@imhere/bridge-contract";
+
+export type Geofence = BridgeMethodResult<"queryGeofences">["items"][number];
+export type EventType = Geofence["eventType"];
+export type RepeatType = Geofence["repeatType"];
+export type ServerRecipient = Geofence["serverRecipients"][number];
+
+export interface RecipientOption {
+  description: string;
+  key: string;
+  label: string;
+  source: "device" | "server";
+  value: string | ServerRecipient;
+}
+
+export interface GeofenceDraft {
+  active: boolean;
+  address: string;
+  customDays: Set<number>;
+  deviceContactIds: Set<string>;
+  eventType: EventType;
+  id?: number;
+  latitude: number;
+  longitude: number;
+  message: string;
+  name: string;
+  radiusMeters: 250 | 500 | 1000;
+  repeatType: RepeatType;
+  serverRecipientKeys: Set<string>;
+}
+
+export const defaultGeofenceDraft: GeofenceDraft = {
+  active: true,
+  address: "",
+  customDays: new Set(),
+  deviceContactIds: new Set(),
+  eventType: "arrival",
+  latitude: 37.5665,
+  longitude: 126.978,
+  message: "안녕하세요! {location}에 도착했습니다.",
+  name: "",
+  radiusMeters: 500,
+  repeatType: "none",
+  serverRecipientKeys: new Set(),
+};
+
+export function draftFromGeofence(geofence: Geofence): GeofenceDraft {
+  return {
+    active: geofence.active,
+    address: geofence.address,
+    customDays: daysFromBitmask(geofence.customDaysBitmask),
+    deviceContactIds: new Set(geofence.deviceContactIds),
+    eventType: geofence.eventType,
+    id: geofence.id,
+    latitude: geofence.latitude,
+    longitude: geofence.longitude,
+    message: geofence.message,
+    name: geofence.name,
+    radiusMeters: geofence.radiusMeters as 250 | 500 | 1000,
+    repeatType: geofence.repeatType,
+    serverRecipientKeys: new Set(
+      geofence.serverRecipients.map(
+        (recipient) => recipient.friendRelationshipId,
+      ),
+    ),
+  };
+}
+
+export function validateGeofenceDraft(draft: GeofenceDraft) {
+  const errors: Record<string, string> = {};
+  if (draft.name.trim().length === 0)
+    errors.name = "장소 이름을 입력해 주세요.";
+  if (draft.address.trim().length === 0)
+    errors.address = "지도에서 장소를 선택해 주세요.";
+  if (draft.message.trim().length === 0)
+    errors.message = "알림 메시지를 입력해 주세요.";
+  if (
+    draft.deviceContactIds.size === 0 &&
+    draft.serverRecipientKeys.size === 0
+  ) {
+    errors.recipients = "알림을 받을 사람을 한 명 이상 선택해 주세요.";
+  }
+  if (draft.repeatType === "custom" && draft.customDays.size === 0) {
+    errors.customDays = "반복할 요일을 한 개 이상 선택해 주세요.";
+  }
+  return errors;
+}
+
+export function toBridgeInput(
+  draft: GeofenceDraft,
+  recipients: RecipientOption[],
+): Parameters<NativeBridge["registerGeofence"]>[0] {
+  return {
+    ...(draft.id === undefined ? {} : { id: draft.id }),
+    name: draft.name.trim(),
+    address: draft.address.trim(),
+    latitude: draft.latitude,
+    longitude: draft.longitude,
+    radiusMeters: draft.radiusMeters,
+    eventType: draft.eventType,
+    repeatType: draft.repeatType,
+    ...(draft.repeatType === "custom"
+      ? { customDaysBitmask: bitmaskFromDays(draft.customDays) }
+      : {}),
+    message: draft.message.trim(),
+    active: draft.active,
+    deviceContactIds: [...draft.deviceContactIds],
+    serverRecipients: recipients.flatMap((recipient) => {
+      if (
+        recipient.source !== "server" ||
+        !draft.serverRecipientKeys.has(recipient.key)
+      ) {
+        return [];
+      }
+      return [recipient.value as ServerRecipient];
+    }),
+  };
+}
+
+export function bitmaskFromDays(days: ReadonlySet<number>) {
+  return [...days].reduce((mask, day) => mask | (1 << day), 0);
+}
+
+export function daysFromBitmask(bitmask?: number) {
+  const days = new Set<number>();
+  if (bitmask === undefined) return days;
+  for (let day = 0; day < 7; day += 1) {
+    if ((bitmask & (1 << day)) !== 0) days.add(day);
+  }
+  return days;
+}

--- a/web/src/pages/geofence/geofence-service.ts
+++ b/web/src/pages/geofence/geofence-service.ts
@@ -1,0 +1,76 @@
+import type { BridgeMethodResult, NativeBridge } from "@imhere/bridge-contract";
+
+import type { ApiClient, SliceResponse } from "@/api/api-client";
+
+import type { Geofence, RecipientOption } from "./geofence-model";
+
+interface FriendUser {
+  email: string;
+  id: string;
+  nickname: string;
+  oAuth2Provider: string;
+}
+
+interface Friendship {
+  friend: FriendUser;
+  friendAlias: string;
+  id: string;
+}
+
+export async function loadGeofences(bridge: NativeBridge) {
+  const result = await bridge.queryGeofences({ limit: 100 });
+  return result.items;
+}
+
+export async function findGeofence(
+  bridge: NativeBridge,
+  id: number,
+): Promise<Geofence | undefined> {
+  return (await loadGeofences(bridge)).find((item) => item.id === id);
+}
+
+export async function loadRecipientOptions(
+  api: ApiClient,
+  bridge: NativeBridge,
+) {
+  const [friendsResult, contactsResult] = await Promise.allSettled([
+    api.request<SliceResponse<Friendship>>("/api/friendships?page=0&size=100"),
+    bridge.getDeviceContacts(),
+  ]);
+  const friends =
+    friendsResult.status === "fulfilled" ? friendsResult.value.content : [];
+  const contacts =
+    contactsResult.status === "fulfilled" ? contactsResult.value : [];
+
+  const serverOptions: RecipientOption[] = friends.map((friendship) => ({
+    key: friendship.id,
+    label: friendship.friendAlias || friendship.friend.nickname,
+    description: friendship.friend.email,
+    source: "server",
+    value: {
+      friendRelationshipId: friendship.id,
+      friendEmail: friendship.friend.email,
+      friendAlias: friendship.friendAlias || friendship.friend.nickname,
+    },
+  }));
+  const knownPhones = new Set<string>();
+  const deviceOptions: RecipientOption[] = contacts.flatMap((contact) => {
+    const phone = contact.phoneNumbers[0]?.replace(/\D/g, "");
+    if (phone === undefined || phone.length === 0 || knownPhones.has(phone)) {
+      return [];
+    }
+    knownPhones.add(phone);
+    return [
+      {
+        key: contact.id,
+        label: contact.displayName,
+        description: contact.phoneNumbers.join(", "),
+        source: "device",
+        value: contact.id,
+      },
+    ];
+  });
+  return [...serverOptions, ...deviceOptions];
+}
+
+export type AutoSendReadiness = BridgeMethodResult<"getAutoSendReadiness">;


### PR DESCRIPTION
## Summary
- migrate geofence list, readiness, toggle, edit, and delete flows to React
- add geofence create/edit form with map, radius, event, repeat, recipients, and native registration
- extend the typed bridge contract and regenerate the Dart bridge model
- add model, component, accessibility, and bridge tests

## Validation
- pnpm lint
- pnpm format:check
- pnpm bridge:check
- pnpm typecheck
- pnpm test
- pnpm build
- flutter analyze lib/shell/bridge/generated/bridge_contract.generated.dart

## Follow-up validation
- forced-quit/reboot and OS geofence trigger behavior require a real device

Closes #89