### PR TITLE
feat(web): migrate friend management screens (F10)

### DIFF
--- a/web/src/pages/friend/FriendAddScreen.tsx
+++ b/web/src/pages/friend/FriendAddScreen.tsx
@@ -1,0 +1,149 @@
+import { type FormEvent, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { useBridge } from "@/bridge/bridge-context";
+
+import type { UserSearchResult } from "./friend-model";
+import { friendService } from "./friend-service";
+
+export function FriendAddScreen() {
+  const api = useApiClient();
+  const bridge = useBridge();
+  const [keyword, setKeyword] = useState("");
+  const [message, setMessage] = useState("ImHere에서 친구가 되어 주세요.");
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [contacts, setContacts] = useState<
+    Awaited<ReturnType<typeof bridge.getDeviceContacts>>
+  >([]);
+  const [status, setStatus] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    void bridge
+      .getDeviceContacts()
+      .then(setContacts)
+      .catch(() => setContacts([]));
+  }, [bridge]);
+
+  const search = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!keyword.trim()) return;
+    setLoading(true);
+    setStatus("");
+    try {
+      const page = await friendService.search(api, keyword.trim());
+      setResults(page.content);
+      if (page.content.length === 0) setStatus("검색 결과가 없습니다.");
+    } catch {
+      setStatus("사용자를 검색하지 못했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const send = async (user: UserSearchResult) => {
+    setStatus("");
+    try {
+      await friendService.sendRequest(api, user.id, message.trim());
+      setStatus(`${user.nickname}님에게 친구 요청을 보냈습니다.`);
+      setResults((current) => current.filter((item) => item.id !== user.id));
+    } catch {
+      setStatus("친구 요청을 보내지 못했습니다.");
+    }
+  };
+
+  return (
+    <main className="feature-page">
+      <Link className="feature-page__back" to="/friend">
+        ← 친구 목록
+      </Link>
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">새 연결</span>
+          <h1>친구 추가</h1>
+          <p>이메일이나 닉네임으로 ImHere 사용자를 찾아보세요.</p>
+        </div>
+      </header>
+      <form className="feature-form" onSubmit={search}>
+        <label className="ds-field">
+          <span className="ds-field__label">이메일 또는 닉네임</span>
+          <input
+            className="ds-field__input"
+            onChange={(event) => setKeyword(event.target.value)}
+            required
+            value={keyword}
+          />
+        </label>
+        <label className="ds-field">
+          <span className="ds-field__label">요청 메시지</span>
+          <textarea
+            className="ds-field__input"
+            maxLength={200}
+            onChange={(event) => setMessage(event.target.value)}
+            value={message}
+          />
+        </label>
+        <button
+          aria-busy={loading}
+          className="ds-button ds-button--primary"
+          disabled={loading}
+          type="submit"
+        >
+          검색
+        </button>
+      </form>
+      {status && <p aria-live="polite">{status}</p>}
+      {results.length > 0 && (
+        <section aria-labelledby="friend-search-results">
+          <h2 id="friend-search-results">검색 결과</h2>
+          <ul className="feature-page__list">
+            {results.map((user) => (
+              <li className="feature-page__list-card" key={user.id}>
+                <div>
+                  <h3>{user.nickname}</h3>
+                  <p>{user.email}</p>
+                </div>
+                <button
+                  className="ds-button ds-button--primary"
+                  onClick={() => void send(user)}
+                  type="button"
+                >
+                  요청 보내기
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <section aria-labelledby="device-contact-heading">
+        <div className="feature-page__section-header">
+          <div>
+            <h2 id="device-contact-heading">기기 연락처 가져오기</h2>
+            <p>연락처를 선택하면 검색어에 전화번호를 채웁니다.</p>
+          </div>
+        </div>
+        <ul className="feature-page__list">
+          {contacts.slice(0, 20).map((contact) => (
+            <li className="feature-page__list-card" key={contact.id}>
+              <div className="feature-page__row">
+                <div>
+                  <h3>{contact.displayName}</h3>
+                  <p>{contact.phoneNumbers.join(", ") || "전화번호 없음"}</p>
+                </div>
+                <button
+                  className="ds-button ds-button--secondary"
+                  disabled={!contact.phoneNumbers[0]}
+                  onClick={() => setKeyword(contact.phoneNumbers[0] ?? "")}
+                  type="button"
+                >
+                  검색에 사용
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/src/pages/friend/FriendListScreen.tsx
+++ b/web/src/pages/friend/FriendListScreen.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { useBridge } from "@/bridge/bridge-context";
+
+import {
+  groupFriends,
+  mergeFriends,
+  type Friendship,
+  type UnifiedFriend,
+} from "./friend-model";
+import { friendService } from "./friend-service";
+import { InfiniteLoadButton } from "./InfiniteLoadButton";
+
+export function FriendListScreen() {
+  const api = useApiClient();
+  const bridge = useBridge();
+  const [relationships, setRelationships] = useState<Friendship[]>([]);
+  const [contacts, setContacts] = useState<
+    Awaited<ReturnType<typeof bridge.getDeviceContacts>>
+  >([]);
+  const [hasNext, setHasNext] = useState(false);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const load = async (nextPage: number, append = false) => {
+    setError("");
+    try {
+      const [friendPage, deviceContacts] = await Promise.all([
+        friendService.list(api, nextPage),
+        nextPage === 0 ? bridge.getDeviceContacts() : Promise.resolve(contacts),
+      ]);
+      setRelationships((current) =>
+        append ? [...current, ...friendPage.content] : friendPage.content,
+      );
+      if (nextPage === 0) setContacts(deviceContacts);
+      setPage(nextPage);
+      setHasNext(friendPage.hasNext);
+    } catch {
+      setError("친구 목록을 불러오지 못했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void Promise.resolve().then(() => load(0));
+    // The first request is intentionally bound to the current bridge/API pair.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, bridge]);
+
+  const groups = useMemo(
+    () => groupFriends(mergeFriends(relationships, contacts)),
+    [contacts, relationships],
+  );
+
+  const mutateRelationship = async (
+    item: Extract<UnifiedFriend, { kind: "server" }>,
+    action: "alias" | "delete" | "block",
+  ) => {
+    try {
+      if (action === "alias") {
+        const alias = window
+          .prompt("새 별명을 입력하세요.", item.displayName)
+          ?.trim();
+        if (!alias) return;
+        const updated = await friendService.updateAlias(
+          api,
+          item.relationship.id,
+          alias,
+        );
+        setRelationships((current) =>
+          current.map((value) => (value.id === updated.id ? updated : value)),
+        );
+        return;
+      }
+      const label = action === "delete" ? "삭제" : "차단";
+      if (!window.confirm(`${item.displayName}님을 ${label}할까요?`)) return;
+      await (action === "delete"
+        ? friendService.delete(api, item.relationship.id)
+        : friendService.block(api, item.relationship.id));
+      setRelationships((current) =>
+        current.filter((value) => value.id !== item.relationship.id),
+      );
+    } catch {
+      setError("친구 정보를 변경하지 못했습니다.");
+    }
+  };
+
+  return (
+    <main className="feature-page">
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">연락처</span>
+          <h1>친구</h1>
+          <p>ImHere 친구와 기기 연락처를 한곳에서 확인하세요.</p>
+        </div>
+        <Link className="ds-button ds-button--primary" to="/friend/add">
+          친구 추가
+        </Link>
+      </header>
+
+      <nav aria-label="친구 관리" className="feature-page__actions">
+        <Link className="ds-button ds-button--secondary" to="/friend/requests">
+          받은 친구 요청
+        </Link>
+        <Link
+          className="ds-button ds-button--secondary"
+          to="/friend/restrictions"
+        >
+          차단·거절 관리
+        </Link>
+      </nav>
+
+      {error && (
+        <p className="feature-page__error" role="alert">
+          {error}
+        </p>
+      )}
+      {loading ? (
+        <p aria-live="polite">친구 목록을 불러오는 중입니다.</p>
+      ) : groups.size === 0 ? (
+        <section className="feature-page__list-card">
+          <h2>아직 등록된 친구가 없어요</h2>
+          <p>닉네임이나 이메일로 친구를 찾아 요청을 보내보세요.</p>
+        </section>
+      ) : (
+        [...groups].map(([group, items]) => (
+          <section aria-labelledby={`friend-group-${group}`} key={group}>
+            <h2 id={`friend-group-${group}`}>{group}</h2>
+            <ul className="feature-page__list">
+              {items.map((item) => (
+                <li className="feature-page__list-card" key={item.id}>
+                  <div className="feature-page__row">
+                    <div>
+                      <h3>{item.displayName}</h3>
+                      <p>{item.description || "전화번호 없음"}</p>
+                    </div>
+                    <span className="feature-page__chip">
+                      {item.kind === "server" ? "ImHere" : "기기"}
+                    </span>
+                  </div>
+                  {item.kind === "server" && (
+                    <div className="feature-page__actions">
+                      <button
+                        className="ds-button ds-button--secondary"
+                        onClick={() => void mutateRelationship(item, "alias")}
+                        type="button"
+                      >
+                        별명 수정
+                      </button>
+                      <button
+                        className="ds-button ds-button--secondary"
+                        onClick={() => void mutateRelationship(item, "delete")}
+                        type="button"
+                      >
+                        삭제
+                      </button>
+                      <button
+                        className="ds-button ds-button--danger"
+                        onClick={() => void mutateRelationship(item, "block")}
+                        type="button"
+                      >
+                        차단
+                      </button>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      )}
+      <InfiniteLoadButton
+        hasNext={hasNext}
+        label="친구 더 보기"
+        load={() => load(page + 1, true)}
+      />
+    </main>
+  );
+}

--- a/web/src/pages/friend/FriendPage.test.tsx
+++ b/web/src/pages/friend/FriendPage.test.tsx
@@ -1,0 +1,71 @@
+import { createMockBridge } from "@imhere/bridge-contract";
+import { render, screen } from "@testing-library/react";
+import axe from "axe-core";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BridgeProvider } from "@/bridge/BridgeProvider";
+
+import FriendPage from "./FriendPage";
+
+const envelope = (data: unknown) =>
+  JSON.stringify({ imhereResponseCode: "SUCCESS", message: "ok", data });
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("FriendPage", () => {
+  it("merges server friends with device contacts and has no accessibility violations", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            envelope({
+              content: [
+                {
+                  id: "relationship-1",
+                  friendAlias: "엄마",
+                  friend: {
+                    id: "friend-1",
+                    email: "mom@example.com",
+                    nickname: "어머니",
+                    oAuth2Provider: "KAKAO",
+                  },
+                  owner: {
+                    id: "me",
+                    email: "me@example.com",
+                    nickname: "나",
+                    oAuth2Provider: "KAKAO",
+                  },
+                  createdAt: "2026-07-26T00:00:00Z",
+                  updatedAt: "2026-07-26T00:00:00Z",
+                },
+              ],
+              hasNext: false,
+            }),
+          ),
+      ),
+    );
+    const controller = createMockBridge({
+      getDeviceContacts: async () => [
+        {
+          id: "contact-1",
+          displayName: "회사",
+          phoneNumbers: ["010-1234-5678"],
+        },
+      ],
+      getAccessToken: async () => ({ accessToken: "token" }),
+    });
+    const { container } = render(
+      <BridgeProvider bridge={controller.bridge}>
+        <MemoryRouter>
+          <FriendPage screen="list" />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "엄마" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "회사" })).toBeVisible();
+    expect((await axe.run(container)).violations).toEqual([]);
+  });
+});

--- a/web/src/pages/friend/FriendPage.tsx
+++ b/web/src/pages/friend/FriendPage.tsx
@@ -1,9 +1,17 @@
-import { PlaceholderScreen } from "@/components/PlaceholderScreen";
+import "@/pages/feature-page.css";
+
+import { FriendAddScreen } from "./FriendAddScreen";
+import { FriendListScreen } from "./FriendListScreen";
+import { FriendRequestScreen } from "./FriendRequestScreen";
+import { FriendRestrictionScreen } from "./FriendRestrictionScreen";
 
 interface FriendPageProps {
   screen: "list" | "add" | "requests" | "restrictions";
 }
 
 export default function FriendPage({ screen }: FriendPageProps) {
-  return <PlaceholderScreen titleKey={`screens.friend.${screen}`} />;
+  if (screen === "add") return <FriendAddScreen />;
+  if (screen === "requests") return <FriendRequestScreen />;
+  if (screen === "restrictions") return <FriendRestrictionScreen />;
+  return <FriendListScreen />;
 }

--- a/web/src/pages/friend/FriendRequestScreen.tsx
+++ b/web/src/pages/friend/FriendRequestScreen.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+
+import type { FriendRequest } from "./friend-model";
+import { friendService } from "./friend-service";
+import { InfiniteLoadButton } from "./InfiniteLoadButton";
+
+export function FriendRequestScreen() {
+  const api = useApiClient();
+  const [requests, setRequests] = useState<FriendRequest[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [status, setStatus] = useState("받은 요청을 불러오는 중입니다.");
+
+  const load = async (nextPage: number, append = false) => {
+    try {
+      const result = await friendService.requests(api, nextPage);
+      setRequests((current) =>
+        append ? [...current, ...result.content] : result.content,
+      );
+      setPage(nextPage);
+      setHasNext(result.hasNext);
+      setStatus(
+        result.content.length === 0 && !append ? "받은 요청이 없어요." : "",
+      );
+    } catch {
+      setStatus("받은 요청을 불러오지 못했습니다.");
+    }
+  };
+
+  useEffect(() => {
+    void Promise.resolve().then(() => load(0));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
+
+  const respond = async (request: FriendRequest, accept: boolean) => {
+    try {
+      await (accept
+        ? friendService.accept(api, request.id)
+        : friendService.reject(api, request.id));
+      setRequests((current) =>
+        current.filter((item) => item.id !== request.id),
+      );
+      setStatus(
+        accept ? "친구 요청을 수락했습니다." : "친구 요청을 거절했습니다.",
+      );
+    } catch {
+      setStatus("친구 요청을 처리하지 못했습니다.");
+    }
+  };
+
+  return (
+    <main className="feature-page">
+      <Link className="feature-page__back" to="/friend">
+        ← 친구 목록
+      </Link>
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">받은 요청</span>
+          <h1>친구 요청</h1>
+          <p>요청 메시지를 확인하고 수락하거나 거절하세요.</p>
+        </div>
+      </header>
+      {status && <p aria-live="polite">{status}</p>}
+      <ul className="feature-page__list">
+        {requests.map((request) => (
+          <li className="feature-page__list-card" key={request.id}>
+            <div>
+              <h2>{request.requester.nickname}</h2>
+              <p>{request.requester.email}</p>
+              <p>{request.message}</p>
+            </div>
+            <div className="feature-page__actions">
+              <button
+                className="ds-button ds-button--primary"
+                onClick={() => void respond(request, true)}
+                type="button"
+              >
+                수락
+              </button>
+              <button
+                className="ds-button ds-button--secondary"
+                onClick={() => void respond(request, false)}
+                type="button"
+              >
+                거절
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <InfiniteLoadButton
+        hasNext={hasNext}
+        label="요청 더 보기"
+        load={() => load(page + 1, true)}
+      />
+    </main>
+  );
+}

--- a/web/src/pages/friend/FriendRestrictionScreen.tsx
+++ b/web/src/pages/friend/FriendRestrictionScreen.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+
+import type { FriendRestriction } from "./friend-model";
+import { friendService } from "./friend-service";
+import { InfiniteLoadButton } from "./InfiniteLoadButton";
+
+export function FriendRestrictionScreen() {
+  const api = useApiClient();
+  const [items, setItems] = useState<FriendRestriction[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [status, setStatus] = useState("차단·거절 목록을 불러오는 중입니다.");
+
+  const load = async (nextPage: number, append = false) => {
+    try {
+      const result = await friendService.restrictions(api, nextPage);
+      setItems((current) =>
+        append ? [...current, ...result.content] : result.content,
+      );
+      setPage(nextPage);
+      setHasNext(result.hasNext);
+      setStatus(
+        result.content.length === 0 && !append ? "제한한 사용자가 없어요." : "",
+      );
+    } catch {
+      setStatus("차단·거절 목록을 불러오지 못했습니다.");
+    }
+  };
+
+  useEffect(() => {
+    void Promise.resolve().then(() => load(0));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
+
+  const unblock = async (item: FriendRestriction) => {
+    if (!window.confirm(`${item.restricted.nickname}님의 제한을 해제할까요?`)) {
+      return;
+    }
+    try {
+      await friendService.unblock(api, item.id);
+      setItems((current) => current.filter((value) => value.id !== item.id));
+      setStatus("제한을 해제했습니다.");
+    } catch {
+      setStatus("제한을 해제하지 못했습니다.");
+    }
+  };
+
+  return (
+    <main className="feature-page">
+      <Link className="feature-page__back" to="/friend">
+        ← 친구 목록
+      </Link>
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">관계 관리</span>
+          <h1>차단·거절 관리</h1>
+          <p>다시 연결할 수 있도록 기존 제한을 해제할 수 있습니다.</p>
+        </div>
+      </header>
+      {status && <p aria-live="polite">{status}</p>}
+      <ul className="feature-page__list">
+        {items.map((item) => (
+          <li className="feature-page__list-card" key={item.id}>
+            <div className="feature-page__row">
+              <div>
+                <h2>{item.restricted.nickname}</h2>
+                <p>{item.restricted.email}</p>
+              </div>
+              <span className="feature-page__chip">
+                {item.type === "BLOCK" ? "차단" : "거절"}
+              </span>
+            </div>
+            <button
+              className="ds-button ds-button--secondary"
+              onClick={() => void unblock(item)}
+              type="button"
+            >
+              제한 해제
+            </button>
+          </li>
+        ))}
+      </ul>
+      <InfiniteLoadButton
+        hasNext={hasNext}
+        label="제한 목록 더 보기"
+        load={() => load(page + 1, true)}
+      />
+    </main>
+  );
+}

--- a/web/src/pages/friend/InfiniteLoadButton.tsx
+++ b/web/src/pages/friend/InfiniteLoadButton.tsx
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface InfiniteLoadButtonProps {
+  hasNext: boolean;
+  label: string;
+  load: () => Promise<void>;
+}
+
+export function InfiniteLoadButton({
+  hasNext,
+  label,
+  load,
+}: InfiniteLoadButtonProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [loading, setLoading] = useState(false);
+
+  const run = useCallback(async () => {
+    if (loading || !hasNext) return;
+    setLoading(true);
+    try {
+      await load();
+    } finally {
+      setLoading(false);
+    }
+  }, [hasNext, load, loading]);
+
+  useEffect(() => {
+    const button = buttonRef.current;
+    if (!hasNext || button === null || !("IntersectionObserver" in window)) {
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) void run();
+    });
+    observer.observe(button);
+    return () => observer.disconnect();
+    // Observer is renewed after each page and loading transition.
+  }, [hasNext, run]);
+
+  if (!hasNext) return null;
+  return (
+    <button
+      aria-busy={loading}
+      className="ds-button ds-button--secondary"
+      disabled={loading}
+      onClick={() => void run()}
+      ref={buttonRef}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}

--- a/web/src/pages/friend/friend-model.test.ts
+++ b/web/src/pages/friend/friend-model.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getNameGroup, groupFriends, mergeFriends } from "./friend-model";
+
+describe("friend grouping", () => {
+  it("derives Korean initial consonants and fallback groups", () => {
+    expect(getNameGroup("김하나")).toBe("ㄱ");
+    expect(getNameGroup("박둘")).toBe("ㅂ");
+    expect(getNameGroup("alice")).toBe("A");
+    expect(getNameGroup("7번")).toBe("0-9");
+  });
+
+  it("merges server friendships and device contacts before grouping", () => {
+    const users = mergeFriends(
+      [
+        {
+          id: "friendship-1",
+          friendAlias: "가족",
+          friend: {
+            id: "friend-1",
+            email: "friend@example.com",
+            nickname: "친구",
+            oAuth2Provider: "KAKAO",
+          },
+          owner: {
+            id: "me",
+            email: "me@example.com",
+            nickname: "나",
+            oAuth2Provider: "KAKAO",
+          },
+          createdAt: "2026-07-26T00:00:00Z",
+          updatedAt: "2026-07-26T00:00:00Z",
+        },
+      ],
+      [{ id: "contact-1", displayName: "나연", phoneNumbers: ["01012345678"] }],
+    );
+
+    expect(users.map((item) => item.kind)).toEqual(["server", "device"]);
+    expect([...groupFriends(users).keys()]).toEqual(["ㄱ", "ㄴ"]);
+  });
+});

--- a/web/src/pages/friend/friend-model.ts
+++ b/web/src/pages/friend/friend-model.ts
@@ -1,0 +1,125 @@
+import type { BridgeMethodResult } from "@imhere/bridge-contract";
+
+type DeviceContact = BridgeMethodResult<"getDeviceContacts">[number];
+
+export interface FriendUser {
+  email: string;
+  id: string;
+  nickname: string;
+  oAuth2Provider: string;
+}
+
+export interface Friendship {
+  createdAt: string;
+  friend: FriendUser;
+  friendAlias: string;
+  id: string;
+  owner: FriendUser;
+  updatedAt: string;
+}
+
+export interface FriendRequest {
+  createdAt: string;
+  id: string;
+  message: string;
+  receiver: FriendUser;
+  requester: FriendUser;
+  updatedAt: string;
+}
+
+export interface FriendRestriction {
+  createdAt: string;
+  expiredAt?: string;
+  id: string;
+  restricted: FriendUser;
+  restrictor: FriendUser;
+  type: string;
+  updatedAt: string;
+}
+
+export type UserSearchResult = FriendUser;
+
+export type UnifiedFriend =
+  | {
+      description: string;
+      displayName: string;
+      id: string;
+      kind: "server";
+      relationship: Friendship;
+    }
+  | {
+      contact: DeviceContact;
+      description: string;
+      displayName: string;
+      id: string;
+      kind: "device";
+    };
+
+const initials = [
+  "ㄱ",
+  "ㄲ",
+  "ㄴ",
+  "ㄷ",
+  "ㄸ",
+  "ㄹ",
+  "ㅁ",
+  "ㅂ",
+  "ㅃ",
+  "ㅅ",
+  "ㅆ",
+  "ㅇ",
+  "ㅈ",
+  "ㅉ",
+  "ㅊ",
+  "ㅋ",
+  "ㅌ",
+  "ㅍ",
+  "ㅎ",
+] as const;
+
+export function getNameGroup(name: string) {
+  const first = name.trim().charAt(0);
+  if (first.length === 0) return "#";
+  const code = first.charCodeAt(0);
+  if (code >= 0xac00 && code <= 0xd7a3) {
+    return initials[Math.floor((code - 0xac00) / 588)] ?? "#";
+  }
+  if (/[a-z]/i.test(first)) return first.toUpperCase();
+  if (/\d/.test(first)) return "0-9";
+  return "#";
+}
+
+export function mergeFriends(
+  relationships: Friendship[],
+  contacts: DeviceContact[],
+) {
+  const items: UnifiedFriend[] = [
+    ...relationships.map((relationship): UnifiedFriend => ({
+      id: relationship.id,
+      kind: "server",
+      displayName:
+        relationship.friendAlias.trim() || relationship.friend.nickname,
+      description: relationship.friend.email,
+      relationship,
+    })),
+    ...contacts.map((contact): UnifiedFriend => ({
+      id: `device:${contact.id}`,
+      kind: "device",
+      displayName: contact.displayName,
+      description: contact.phoneNumbers.join(", "),
+      contact,
+    })),
+  ];
+
+  return items.sort((left, right) =>
+    left.displayName.localeCompare(right.displayName, "ko"),
+  );
+}
+
+export function groupFriends(items: UnifiedFriend[]) {
+  return items.reduce<Map<string, UnifiedFriend[]>>((groups, item) => {
+    const key = getNameGroup(item.displayName);
+    groups.set(key, [...(groups.get(key) ?? []), item]);
+    return groups;
+  }, new Map());
+}

--- a/web/src/pages/friend/friend-service.ts
+++ b/web/src/pages/friend/friend-service.ts
@@ -1,0 +1,68 @@
+import type { ApiClient, SliceResponse } from "@/api/api-client";
+
+import type {
+  FriendRequest,
+  FriendRestriction,
+  Friendship,
+  UserSearchResult,
+} from "./friend-model";
+
+const pageQuery = (page: number, size = 20) => `page=${page}&size=${size}`;
+
+export const friendService = {
+  list(api: ApiClient, page: number) {
+    return api.request<SliceResponse<Friendship>>(
+      `/api/friendships?${pageQuery(page)}`,
+    );
+  },
+  updateAlias(api: ApiClient, id: string, alias: string) {
+    return api.request<Friendship>(`/api/friendships/${id}/alias`, {
+      method: "PATCH",
+      body: JSON.stringify({ alias }),
+    });
+  },
+  delete(api: ApiClient, id: string) {
+    return api.request<void>(`/api/friendships/${id}`, { method: "DELETE" });
+  },
+  block(api: ApiClient, id: string) {
+    return api.request<void>(`/api/friendships/${id}/block`, {
+      method: "POST",
+    });
+  },
+  search(api: ApiClient, keyword: string, page = 0) {
+    return api.request<SliceResponse<UserSearchResult>>(
+      `/api/users?keyword=${encodeURIComponent(keyword)}&${pageQuery(page)}`,
+    );
+  },
+  sendRequest(api: ApiClient, targetId: string, message: string) {
+    return api.request<{ friendRequestId: string }>("/api/friends/requests", {
+      method: "POST",
+      body: JSON.stringify({ targetId, message }),
+    });
+  },
+  requests(api: ApiClient, page: number) {
+    return api.request<SliceResponse<FriendRequest>>(
+      `/api/friends/requests?type=RECEIVED&${pageQuery(page)}`,
+    );
+  },
+  accept(api: ApiClient, id: string) {
+    return api.request<Friendship>(`/api/friends/requests/${id}/accept`, {
+      method: "POST",
+    });
+  },
+  reject(api: ApiClient, id: string) {
+    return api.request<void>(`/api/friends/requests/${id}/reject`, {
+      method: "POST",
+    });
+  },
+  restrictions(api: ApiClient, page: number) {
+    return api.request<SliceResponse<FriendRestriction>>(
+      `/api/friends/restrictions?${pageQuery(page)}`,
+    );
+  },
+  unblock(api: ApiClient, id: string) {
+    return api.request<void>(`/api/friends/restrictions/${id}`, {
+      method: "DELETE",
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- merge server friendships and device contacts with Korean initial-consonant grouping
- add alias, delete, block, search, contact import, and friend-request flows
- add received-request accept/reject and restriction-unblock screens
- consume SliceResponse pages with intersection-based continuous loading and button fallback
- add model and accessibility tests

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test (14 files, 51 tests)
- pnpm build

Closes #90