### PR TITLE
feat(web): migrate activity record screens (F11)

### DIFF
--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -1,5 +1,9 @@
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { normalizePushPath } from "@/pages/record/record-model";
 
 const tabs = [
   {
@@ -22,6 +26,16 @@ const tabs = [
 
 export function AppShell() {
   const { t } = useTranslation();
+  const bridge = useBridge();
+  const navigate = useNavigate();
+
+  useEffect(
+    () =>
+      bridge.events.subscribe("onPushOpened", ({ path }) => {
+        navigate(normalizePushPath(path));
+      }),
+    [bridge, navigate],
+  );
 
   return (
     <div className="app-shell">

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -96,7 +96,7 @@ export const appRoutes: RouteObject[] = [
             element: <RecordPage screen="notifications" />,
           },
           {
-            path: "record/notifications/detail",
+            path: "record/notifications/:recordId",
             element: <RecordPage screen="notificationDetail" />,
           },
           {
@@ -108,7 +108,7 @@ export const appRoutes: RouteObject[] = [
             element: <RecordPage screen="sendHistory" />,
           },
           {
-            path: "record/send-history/detail",
+            path: "record/send-history/:recordId",
             element: <RecordPage screen="sendHistoryDetail" />,
           },
           {

--- a/web/src/pages/record/NotificationListScreen.tsx
+++ b/web/src/pages/record/NotificationListScreen.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { InfiniteLoadButton } from "@/pages/friend/InfiniteLoadButton";
+
+import { formatActivityTime, type NativeNotification } from "./record-model";
+
+export function NotificationListScreen() {
+  const bridge = useBridge();
+  const [items, setItems] = useState<NativeNotification[]>([]);
+  const [cursor, setCursor] = useState<string>();
+  const [status, setStatus] = useState("알림을 불러오는 중입니다.");
+
+  const load = async (append = false) => {
+    try {
+      const page = await bridge.queryNotifications({
+        limit: 20,
+        ...(append && cursor ? { cursor } : {}),
+      });
+      setItems((current) =>
+        append ? [...current, ...page.items] : page.items,
+      );
+      setCursor(page.nextCursor);
+      setStatus(
+        page.items.length === 0 && !append ? "받은 알림이 없어요." : "",
+      );
+    } catch {
+      setStatus("알림을 불러오지 못했습니다.");
+    }
+  };
+
+  useEffect(() => {
+    void Promise.resolve().then(() => load());
+    return bridge.events.subscribe("onAppResumed", () => void load());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bridge]);
+
+  return (
+    <RecordListLayout
+      back="/record"
+      description="기기에 안전하게 저장된 푸시 알림입니다."
+      eyebrow="수신함"
+      title="받은 알림"
+    >
+      {status && <p aria-live="polite">{status}</p>}
+      <ul className="feature-page__list">
+        {items.map((item) => (
+          <li className="feature-page__list-card" key={item.id}>
+            <Link to={`/record/notifications/${item.id}`}>
+              <h2>{item.title}</h2>
+            </Link>
+            <p>{item.body}</p>
+            <small>{formatActivityTime(item.createdAt)}</small>
+          </li>
+        ))}
+      </ul>
+      <InfiniteLoadButton
+        hasNext={cursor !== undefined}
+        label="알림 더 보기"
+        load={() => load(true)}
+      />
+    </RecordListLayout>
+  );
+}
+
+export function RecordListLayout({
+  back,
+  eyebrow,
+  title,
+  description,
+  children,
+}: {
+  back: string;
+  children: React.ReactNode;
+  description: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <main className="feature-page">
+      <Link className="feature-page__back" to={back}>
+        ← 기록
+      </Link>
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">{eyebrow}</span>
+          <h1>{title}</h1>
+          <p>{description}</p>
+        </div>
+      </header>
+      {children}
+    </main>
+  );
+}

--- a/web/src/pages/record/RecordDetailScreen.tsx
+++ b/web/src/pages/record/RecordDetailScreen.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+
+import {
+  formatActivityTime,
+  type DeliveryRecord,
+  type NativeNotification,
+} from "./record-model";
+
+export function RecordDetailScreen({
+  kind,
+}: {
+  kind: "notification" | "record";
+}) {
+  const bridge = useBridge();
+  const params = useParams();
+  const id = Number(params.recordId);
+  const [item, setItem] = useState<
+    DeliveryRecord | NativeNotification | undefined
+  >();
+  const [status, setStatus] = useState("상세 기록을 불러오는 중입니다.");
+
+  useEffect(() => {
+    void Promise.resolve().then(async () => {
+      try {
+        const page =
+          kind === "notification"
+            ? await bridge.queryNotifications({ limit: 100 })
+            : await bridge.queryRecords({ limit: 100 });
+        const found = page.items.find((value) => value.id === id);
+        setItem(found);
+        setStatus(found ? "" : "기록을 찾지 못했습니다.");
+      } catch {
+        setStatus("상세 기록을 불러오지 못했습니다.");
+      }
+    });
+  }, [bridge, id, kind]);
+
+  const back =
+    kind === "notification" ? "/record/notifications" : "/record/send-history";
+  return (
+    <main className="feature-page">
+      <Link className="feature-page__back" to={back}>
+        ← 목록으로
+      </Link>
+      {status && <p aria-live="polite">{status}</p>}
+      {item && (
+        <article className="feature-page__list-card">
+          <span className="feature-page__eyebrow">
+            {kind === "notification" ? "받은 알림" : "전송 기록"}
+          </span>
+          <h1>{"title" in item ? item.title : item.geofenceName}</h1>
+          <p>{"body" in item ? item.body : item.message}</p>
+          <dl>
+            <dt>시간</dt>
+            <dd>
+              {formatActivityTime(
+                "createdAt" in item ? item.createdAt : item.occurredAt,
+              )}
+            </dd>
+            {"senderNickname" in item && item.senderNickname && (
+              <>
+                <dt>보낸 사람</dt>
+                <dd>{item.senderNickname}</dd>
+              </>
+            )}
+            {"status" in item && (
+              <>
+                <dt>상태</dt>
+                <dd>{item.status}</dd>
+              </>
+            )}
+          </dl>
+        </article>
+      )}
+    </main>
+  );
+}

--- a/web/src/pages/record/RecordFriendRequestScreen.tsx
+++ b/web/src/pages/record/RecordFriendRequestScreen.tsx
@@ -1,0 +1,5 @@
+import { FriendRequestScreen } from "@/pages/friend/FriendRequestScreen";
+
+export function RecordFriendRequestScreen() {
+  return <FriendRequestScreen />;
+}

--- a/web/src/pages/record/RecordOverviewScreen.tsx
+++ b/web/src/pages/record/RecordOverviewScreen.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { useBridge } from "@/bridge/bridge-context";
+import type { FriendRequest } from "@/pages/friend/friend-model";
+import { friendService } from "@/pages/friend/friend-service";
+
+import {
+  formatActivityTime,
+  type DeliveryRecord,
+  type NativeNotification,
+} from "./record-model";
+
+export function RecordOverviewScreen() {
+  const api = useApiClient();
+  const bridge = useBridge();
+  const [notifications, setNotifications] = useState<NativeNotification[]>([]);
+  const [records, setRecords] = useState<DeliveryRecord[]>([]);
+  const [requests, setRequests] = useState<FriendRequest[]>([]);
+  const [status, setStatus] = useState("활동 기록을 불러오는 중입니다.");
+
+  const refresh = async () => {
+    const [notificationResult, recordResult, requestResult] =
+      await Promise.allSettled([
+        bridge.queryNotifications({ limit: 3 }),
+        bridge.queryRecords({ limit: 3 }),
+        friendService.requests(api, 0),
+      ]);
+    setNotifications(
+      notificationResult.status === "fulfilled"
+        ? notificationResult.value.items
+        : [],
+    );
+    setRecords(
+      recordResult.status === "fulfilled" ? recordResult.value.items : [],
+    );
+    setRequests(
+      requestResult.status === "fulfilled"
+        ? requestResult.value.content.slice(0, 3)
+        : [],
+    );
+    setStatus(
+      [notificationResult, recordResult, requestResult].every(
+        (result) => result.status === "rejected",
+      )
+        ? "활동 기록을 불러오지 못했습니다."
+        : "",
+    );
+  };
+
+  useEffect(() => {
+    void Promise.resolve().then(refresh);
+    return bridge.events.subscribe("onAppResumed", () => {
+      void refresh();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, bridge]);
+
+  return (
+    <main className="feature-page">
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">최근 활동</span>
+          <h1>기록</h1>
+          <p>받은 알림, 친구 요청, 자동 전송 결과를 확인하세요.</p>
+        </div>
+        <button
+          className="ds-button ds-button--secondary"
+          onClick={() => void refresh()}
+          type="button"
+        >
+          새로고침
+        </button>
+      </header>
+      {status && <p aria-live="polite">{status}</p>}
+
+      <ActivitySection
+        empty="최근 받은 알림이 없어요."
+        link="/record/notifications"
+        title="받은 알림"
+      >
+        {notifications.map((item) => (
+          <li className="feature-page__list-card" key={item.id}>
+            <h3>{item.title}</h3>
+            <p>{item.body}</p>
+            <small>{formatActivityTime(item.createdAt)}</small>
+          </li>
+        ))}
+      </ActivitySection>
+
+      <ActivitySection
+        empty="대기 중인 친구 요청이 없어요."
+        link="/record/friend-requests"
+        title="친구 요청"
+      >
+        {requests.map((item) => (
+          <li className="feature-page__list-card" key={item.id}>
+            <h3>{item.requester.nickname}</h3>
+            <p>{item.message}</p>
+            <small>{formatActivityTime(item.createdAt)}</small>
+          </li>
+        ))}
+      </ActivitySection>
+
+      <ActivitySection
+        empty="자동 전송 기록이 없어요."
+        link="/record/send-history"
+        title="전송 기록"
+      >
+        {records.map((item) => (
+          <li className="feature-page__list-card" key={item.id}>
+            <h3>{item.geofenceName}</h3>
+            <p>{item.message}</p>
+            <div className="feature-page__meta">
+              <span className="feature-page__chip">{item.status}</span>
+              <small>{formatActivityTime(item.occurredAt)}</small>
+            </div>
+          </li>
+        ))}
+      </ActivitySection>
+    </main>
+  );
+}
+
+function ActivitySection({
+  title,
+  link,
+  empty,
+  children,
+}: {
+  children: React.ReactNode;
+  empty: string;
+  link: string;
+  title: string;
+}) {
+  const hasChildren = Array.isArray(children)
+    ? children.length > 0
+    : !!children;
+  return (
+    <section aria-labelledby={`activity-${link}`}>
+      <div className="feature-page__section-header">
+        <h2 id={`activity-${link}`}>{title}</h2>
+        <Link to={link}>전체 보기</Link>
+      </div>
+      {hasChildren ? (
+        <ul className="feature-page__list">{children}</ul>
+      ) : (
+        <p>{empty}</p>
+      )}
+    </section>
+  );
+}

--- a/web/src/pages/record/RecordPage.test.tsx
+++ b/web/src/pages/record/RecordPage.test.tsx
@@ -1,0 +1,75 @@
+import { createMockBridge } from "@imhere/bridge-contract";
+import { render, screen, waitFor } from "@testing-library/react";
+import axe from "axe-core";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BridgeProvider } from "@/bridge/BridgeProvider";
+
+import RecordPage from "./RecordPage";
+
+const envelope = (data: unknown) =>
+  JSON.stringify({ imhereResponseCode: "SUCCESS", message: "ok", data });
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("RecordPage", () => {
+  it("combines native records with server requests and refreshes on resume", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(envelope({ content: [], hasNext: false })),
+      ),
+    );
+    const controller = createMockBridge({
+      getAccessToken: async () => ({ accessToken: "token" }),
+      queryNotifications: async () => ({
+        items: [
+          {
+            id: 1,
+            title: "도착 알림",
+            body: "민수가 회사에 도착했어요.",
+            createdAt: "2026-07-26T00:00:00Z",
+          },
+        ],
+      }),
+      queryRecords: async () => ({
+        items: [
+          {
+            id: 2,
+            geofenceId: 7,
+            geofenceName: "회사",
+            eventType: "arrival",
+            status: "completed",
+            occurredAt: "2026-07-26T00:00:00Z",
+            message: "회사에 도착했습니다.",
+          },
+        ],
+      }),
+    });
+    const { container } = render(
+      <BridgeProvider bridge={controller.bridge}>
+        <MemoryRouter>
+          <RecordPage screen="overview" />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "도착 알림" }),
+    ).toBeVisible();
+    expect(screen.getByRole("heading", { name: "회사" })).toBeVisible();
+    expect((await axe.run(container)).violations).toEqual([]);
+
+    const before = controller.calls.filter(
+      (call) => call.method === "queryNotifications",
+    ).length;
+    controller.emit("onAppResumed", undefined);
+    await waitFor(() =>
+      expect(
+        controller.calls.filter((call) => call.method === "queryNotifications")
+          .length,
+      ).toBeGreaterThan(before),
+    );
+  });
+});

--- a/web/src/pages/record/RecordPage.tsx
+++ b/web/src/pages/record/RecordPage.tsx
@@ -1,4 +1,10 @@
-import { PlaceholderScreen } from "@/components/PlaceholderScreen";
+import "@/pages/feature-page.css";
+
+import { NotificationListScreen } from "./NotificationListScreen";
+import { RecordDetailScreen } from "./RecordDetailScreen";
+import { RecordFriendRequestScreen } from "./RecordFriendRequestScreen";
+import { RecordOverviewScreen } from "./RecordOverviewScreen";
+import { SendHistoryScreen } from "./SendHistoryScreen";
 
 type RecordScreen =
   | "overview"
@@ -13,5 +19,14 @@ interface RecordPageProps {
 }
 
 export default function RecordPage({ screen }: RecordPageProps) {
-  return <PlaceholderScreen titleKey={`screens.record.${screen}`} />;
+  if (screen === "notifications") return <NotificationListScreen />;
+  if (screen === "notificationDetail") {
+    return <RecordDetailScreen kind="notification" />;
+  }
+  if (screen === "friendRequests") return <RecordFriendRequestScreen />;
+  if (screen === "sendHistory") return <SendHistoryScreen />;
+  if (screen === "sendHistoryDetail") {
+    return <RecordDetailScreen kind="record" />;
+  }
+  return <RecordOverviewScreen />;
 }

--- a/web/src/pages/record/SendHistoryScreen.tsx
+++ b/web/src/pages/record/SendHistoryScreen.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { useBridge } from "@/bridge/bridge-context";
+import { InfiniteLoadButton } from "@/pages/friend/InfiniteLoadButton";
+
+import { RecordListLayout } from "./NotificationListScreen";
+import { formatActivityTime, type DeliveryRecord } from "./record-model";
+
+export function SendHistoryScreen() {
+  const bridge = useBridge();
+  const [items, setItems] = useState<DeliveryRecord[]>([]);
+  const [cursor, setCursor] = useState<string>();
+  const [status, setStatus] = useState("전송 기록을 불러오는 중입니다.");
+
+  const load = async (append = false) => {
+    try {
+      const page = await bridge.queryRecords({
+        limit: 20,
+        ...(append && cursor ? { cursor } : {}),
+      });
+      setItems((current) =>
+        append ? [...current, ...page.items] : page.items,
+      );
+      setCursor(page.nextCursor);
+      setStatus(
+        page.items.length === 0 && !append ? "전송 기록이 없어요." : "",
+      );
+    } catch {
+      setStatus("전송 기록을 불러오지 못했습니다.");
+    }
+  };
+
+  useEffect(() => {
+    void Promise.resolve().then(() => load());
+    return bridge.events.subscribe("onAppResumed", () => void load());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bridge]);
+
+  return (
+    <RecordListLayout
+      back="/record"
+      description="네이티브 자동 전송 파이프라인이 남긴 결과입니다."
+      eyebrow="자동 알림"
+      title="전송 기록"
+    >
+      {status && <p aria-live="polite">{status}</p>}
+      <ul className="feature-page__list">
+        {items.map((item) => (
+          <li className="feature-page__list-card" key={item.id}>
+            <Link to={`/record/send-history/${item.id}`}>
+              <h2>{item.geofenceName}</h2>
+            </Link>
+            <p>{item.message}</p>
+            <div className="feature-page__meta">
+              <span className="feature-page__chip">{item.status}</span>
+              <span>{formatActivityTime(item.occurredAt)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <InfiniteLoadButton
+        hasNext={cursor !== undefined}
+        label="전송 기록 더 보기"
+        load={() => load(true)}
+      />
+    </RecordListLayout>
+  );
+}

--- a/web/src/pages/record/record-model.test.ts
+++ b/web/src/pages/record/record-model.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizePushPath } from "./record-model";
+
+describe("normalizePushPath", () => {
+  it("removes the WebView basename from native push paths", () => {
+    expect(normalizePushPath("/app/record/notifications/3")).toBe(
+      "/record/notifications/3",
+    );
+  });
+
+  it("rejects external and malformed navigation targets", () => {
+    expect(normalizePushPath("https://attacker.example")).toBe("/record");
+    expect(normalizePushPath("//attacker.example")).toBe("/record");
+    expect(normalizePushPath("\\record")).toBe("/record");
+  });
+});

--- a/web/src/pages/record/record-model.ts
+++ b/web/src/pages/record/record-model.ts
@@ -1,0 +1,33 @@
+import type { BridgeMethodResult } from "@imhere/bridge-contract";
+
+export type DeliveryRecord =
+  BridgeMethodResult<"queryRecords">["items"][number];
+export type NativeNotification =
+  BridgeMethodResult<"queryNotifications">["items"][number];
+
+export function formatActivityTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function normalizePushPath(path: string) {
+  const trimmed = path.trim();
+  const normalized = trimmed.startsWith("/app/")
+    ? trimmed.slice(4)
+    : trimmed === "/app"
+      ? "/record"
+      : trimmed;
+  if (
+    !normalized.startsWith("/") ||
+    normalized.startsWith("//") ||
+    normalized.includes("\\") ||
+    normalized.includes(":")
+  ) {
+    return "/record";
+  }
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- combine native SQLite notifications and delivery records with server friend requests
- add overview, paginated lists, and native-backed detail screens
- refresh activity data when the native shell emits onAppResumed
- route validated onPushOpened paths through React Router
- add accessibility, refresh-event, and path-sanitization tests

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test (16 files, 54 tests)
- pnpm build

Closes #91