### PR TITLE
feat(web): migrate settings screens (F12)

### DIFF
--- a/web/src/design-system/ThemeProvider.tsx
+++ b/web/src/design-system/ThemeProvider.tsx
@@ -1,4 +1,12 @@
-import { type PropsWithChildren, useEffect, useMemo, useState } from "react";
+import {
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { BridgeContext } from "@/bridge/bridge-context";
 
 import {
   type AppTheme,
@@ -20,12 +28,36 @@ function getInitialTheme(): AppTheme {
 
 export function ThemeProvider({ children }: PropsWithChildren) {
   const [theme, setTheme] = useState<AppTheme>(getInitialTheme);
+  const bridge = useContext(BridgeContext);
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
     document.documentElement.style.colorScheme = theme;
     globalThis.localStorage?.setItem(storageKey, theme);
-  }, [theme]);
+    void bridge
+      ?.setStatusBarStyle({ style: theme === "dark" ? "light" : "dark" })
+      .catch(() => undefined);
+  }, [bridge, theme]);
+
+  useEffect(() => {
+    if (bridge === null) return;
+    void bridge
+      .getAppInfo()
+      .then((info) => {
+        if (info.theme === "light" || info.theme === "dark") {
+          setTheme(info.theme);
+        }
+      })
+      .catch(() => undefined);
+    return bridge.events.subscribe("onThemeChanged", ({ theme: next }) => {
+      if (next === "light" || next === "dark") setTheme(next);
+      else {
+        setTheme(
+          matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
+        );
+      }
+    });
+  }, [bridge]);
 
   const value = useMemo<ThemeContextValue>(
     () => ({

--- a/web/src/locales/ko/translation.json
+++ b/web/src/locales/ko/translation.json
@@ -69,6 +69,8 @@
       "needsSetup": "{{count}}개 설정 필요",
       "permissionWarning": "백그라운드 자동 전송을 위해 권한 설정이 필요합니다.",
       "openPermission": "설정 확인",
+      "iosLimit": "iPhone은 활성 지오펜스를 최대 20개까지 등록합니다. 현재 {{count}}개가 활성화되어 있어요.",
+      "oneShotHint": "‘반복 안 함’ 장소는 첫 알림 후 자동으로 비활성화되고 OS 감지 목록에서도 해제됩니다.",
       "loadError": "알림 장소를 불러오지 못했습니다.",
       "loading": "알림 장소를 불러오는 중",
       "emptyTitle": "등록한 알림 장소가 없어요",

--- a/web/src/pages/geofence/GeofenceListScreen.tsx
+++ b/web/src/pages/geofence/GeofenceListScreen.tsx
@@ -17,14 +17,17 @@ export function GeofenceListScreen() {
   const [readiness, setReadiness] =
     useState<BridgeMethodResult<"getAutoSendReadiness"> | null>(null);
   const [locationEnabled, setLocationEnabled] = useState<boolean | null>(null);
+  const [platform, setPlatform] =
+    useState<BridgeMethodResult<"getAppInfo">["platform"]>("browser");
   const [error, setError] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Geofence | null>(null);
 
   const load = useCallback(async () => {
-    const [geofences, autoSend, location] = await Promise.allSettled([
+    const [geofences, autoSend, location, appInfo] = await Promise.allSettled([
       loadGeofences(bridge),
       bridge.getAutoSendReadiness(),
       bridge.getLocationServiceStatus(),
+      bridge.getAppInfo(),
     ]);
     if (geofences.status === "fulfilled") {
       setItems(geofences.value);
@@ -37,6 +40,7 @@ export function GeofenceListScreen() {
     if (location.status === "fulfilled") {
       setLocationEnabled(location.value.status === "enabled");
     }
+    if (appInfo.status === "fulfilled") setPlatform(appInfo.value.platform);
   }, [bridge, t]);
 
   useEffect(() => {
@@ -115,6 +119,16 @@ export function GeofenceListScreen() {
           <Link to="/user-permission">{t("geofence.list.openPermission")}</Link>
         </div>
       ) : null}
+      {platform === "ios" && items !== null ? (
+        <div className="feature-page__banner" role="status">
+          {t("geofence.list.iosLimit", {
+            count: items.filter((item) => item.active).length,
+          })}
+        </div>
+      ) : null}
+      <div className="feature-page__banner" role="note">
+        {t("geofence.list.oneShotHint")}
+      </div>
       {error === null ? null : (
         <p className="feature-page__error" role="alert">
           {error}{" "}

--- a/web/src/pages/record/SendHistoryScreen.tsx
+++ b/web/src/pages/record/SendHistoryScreen.tsx
@@ -37,6 +37,17 @@ export function SendHistoryScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bridge]);
 
+  const remove = async (item: DeliveryRecord) => {
+    if (!window.confirm(`${item.geofenceName} 전송 기록을 삭제할까요?`)) return;
+    try {
+      await bridge.deleteRecord({ id: item.id });
+      setItems((current) => current.filter((value) => value.id !== item.id));
+      setStatus("전송 기록을 삭제했습니다.");
+    } catch {
+      setStatus("전송 기록을 삭제하지 못했습니다.");
+    }
+  };
+
   return (
     <RecordListLayout
       back="/record"
@@ -56,6 +67,13 @@ export function SendHistoryScreen() {
               <span className="feature-page__chip">{item.status}</span>
               <span>{formatActivityTime(item.occurredAt)}</span>
             </div>
+            <button
+              className="ds-button ds-button--danger"
+              onClick={() => void remove(item)}
+              type="button"
+            >
+              기록 삭제
+            </button>
           </li>
         ))}
       </ul>

--- a/web/src/pages/setting/SettingPage.test.tsx
+++ b/web/src/pages/setting/SettingPage.test.tsx
@@ -1,0 +1,138 @@
+import { createMockBridge } from "@imhere/bridge-contract";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import axe from "axe-core";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BridgeProvider } from "@/bridge/BridgeProvider";
+import { ThemeProvider } from "@/design-system";
+
+import SettingPage from "./SettingPage";
+
+const envelope = (data: unknown) =>
+  JSON.stringify({ imhereResponseCode: "SUCCESS", message: "ok", data });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.documentElement.removeAttribute("data-theme");
+});
+
+describe("SettingPage", () => {
+  it("shows API account data and native app diagnostics accessibly", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = String(input);
+        return new Response(
+          envelope(
+            path.includes("/api/users/my")
+              ? {
+                  id: "me",
+                  email: "me@example.com",
+                  nickname: "고동수",
+                  oAuth2Provider: "KAKAO",
+                }
+              : [],
+          ),
+        );
+      }),
+    );
+    const controller = createMockBridge({
+      getAccessToken: async () => ({ accessToken: "token" }),
+      getAppInfo: async () => ({
+        appVersion: "2.0.0",
+        buildNumber: "42",
+        platform: "android",
+        locale: "ko-KR",
+        theme: "light",
+      }),
+      getAutoSendReadiness: async () => ({
+        ready: true,
+        locationAlways: true,
+        locationService: true,
+        notification: true,
+        batteryOptimization: true,
+        missing: [],
+      }),
+      queryRecords: async () => ({ items: [] }),
+    });
+    const { container } = render(
+      <BridgeProvider bridge={controller.bridge}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <SettingPage />
+          </MemoryRouter>
+        </ThemeProvider>
+      </BridgeProvider>,
+    );
+
+    expect(await screen.findByText("고동수")).toBeVisible();
+    expect(screen.getByText("2.0.0 (42)")).toBeVisible();
+    expect((await axe.run(container)).violations).toEqual([]);
+  });
+
+  it("follows native theme changes and synchronizes the status bar", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (input: RequestInfo | URL) =>
+          new Response(
+            envelope(
+              String(input).includes("/api/users/my")
+                ? {
+                    id: "me",
+                    email: "me@example.com",
+                    nickname: "나",
+                    oAuth2Provider: "KAKAO",
+                  }
+                : [],
+            ),
+          ),
+      ),
+    );
+    const controller = createMockBridge({
+      getAppInfo: async () => ({
+        appVersion: "2.0.0",
+        buildNumber: "42",
+        platform: "android",
+        locale: "ko-KR",
+        theme: "light",
+      }),
+      getAutoSendReadiness: async () => ({
+        ready: false,
+        locationAlways: false,
+        locationService: true,
+        notification: false,
+        batteryOptimization: false,
+        missing: ["locationAlways"],
+      }),
+      queryRecords: async () => ({ items: [] }),
+    });
+    render(
+      <BridgeProvider bridge={controller.bridge}>
+        <ThemeProvider>
+          <MemoryRouter>
+            <SettingPage />
+          </MemoryRouter>
+        </ThemeProvider>
+      </BridgeProvider>,
+    );
+
+    await screen.findByText("2.0.0 (42)");
+    const emitTheme = controller.emit as unknown as (
+      event: "onThemeChanged",
+      payload: { theme: "dark" },
+    ) => void;
+    act(() => emitTheme("onThemeChanged", { theme: "dark" }));
+    await waitFor(() =>
+      expect(document.documentElement.dataset.theme).toBe("dark"),
+    );
+    expect(
+      controller.calls.some(
+        (call) =>
+          call.method === "setStatusBarStyle" &&
+          (call.args[0] as { style: string }).style === "light",
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/src/pages/setting/SettingPage.tsx
+++ b/web/src/pages/setting/SettingPage.tsx
@@ -1,5 +1,327 @@
-import { PlaceholderScreen } from "@/components/PlaceholderScreen";
+import "./setting.css";
+import "@/pages/feature-page.css";
+
+import type { BridgeMethodResult } from "@imhere/bridge-contract";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useApiClient } from "@/api/use-api-client";
+import { useBridge } from "@/bridge/bridge-context";
+import { useTheme } from "@/design-system";
+import { loadTerms, type Term } from "@/pages/onboarding/terms-service";
+import { formatActivityTime } from "@/pages/record/record-model";
+
+import { settingService, SUPPORT_URL, type UserMe } from "./setting-service";
+
+type AppInfo = BridgeMethodResult<"getAppInfo">;
+type Readiness = BridgeMethodResult<"getAutoSendReadiness">;
+type Record = BridgeMethodResult<"queryRecords">["items"][number];
 
 export default function SettingPage() {
-  return <PlaceholderScreen titleKey="screens.setting.main" />;
+  const api = useApiClient();
+  const bridge = useBridge();
+  const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
+  const [me, setMe] = useState<UserMe>();
+  const [appInfo, setAppInfo] = useState<AppInfo>();
+  const [readiness, setReadiness] = useState<Readiness>();
+  const [lastRecord, setLastRecord] = useState<Record>();
+  const [terms, setTerms] = useState<Term[]>([]);
+  const [contactAccess, setContactAccess] = useState(false);
+  const [status, setStatus] = useState("설정 정보를 불러오는 중입니다.");
+
+  const refreshNative = async () => {
+    const [infoResult, readinessResult, recordResult] =
+      await Promise.allSettled([
+        bridge.getAppInfo(),
+        bridge.getAutoSendReadiness(),
+        bridge.queryRecords({ limit: 1 }),
+      ]);
+    if (infoResult.status === "fulfilled") setAppInfo(infoResult.value);
+    if (readinessResult.status === "fulfilled") {
+      setReadiness(readinessResult.value);
+    }
+    if (recordResult.status === "fulfilled") {
+      setLastRecord(recordResult.value.items[0]);
+    }
+  };
+
+  useEffect(() => {
+    void Promise.allSettled([
+      settingService.me(api).then(setMe),
+      loadTerms(api).then(setTerms),
+      Promise.resolve().then(refreshNative),
+    ]).then((results) => {
+      setStatus(
+        results.every((result) => result.status === "rejected")
+          ? "설정 정보를 불러오지 못했습니다."
+          : "",
+      );
+    });
+    const unsubscribeResume = bridge.events.subscribe(
+      "onAppResumed",
+      () => void refreshNative(),
+    );
+    const unsubscribePermission = bridge.events.subscribe(
+      "onPermissionChanged",
+      () => void refreshNative(),
+    );
+    return () => {
+      unsubscribeResume();
+      unsubscribePermission();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, bridge]);
+
+  const editNickname = async () => {
+    const nickname = window
+      .prompt("새 닉네임을 입력하세요.", me?.nickname)
+      ?.trim();
+    if (!nickname || nickname.length > 30) return;
+    try {
+      setMe(await settingService.changeNickname(api, nickname));
+      setStatus("닉네임을 변경했습니다.");
+    } catch {
+      setStatus("닉네임을 변경하지 못했습니다.");
+    }
+  };
+
+  const openPermission = async (
+    permission: "locationAlways" | "notification" | "batteryOptimization",
+    granted: boolean,
+  ) => {
+    try {
+      if (granted) await bridge.openAppSettings();
+      else await bridge.requestPermission({ permission });
+      await refreshNative();
+    } catch {
+      setStatus("권한 설정을 열지 못했습니다.");
+    }
+  };
+
+  const signOut = async () => {
+    if (!window.confirm("로그아웃할까요?")) return;
+    await bridge.signOut();
+    navigate("/auth", { replace: true });
+  };
+
+  const withdraw = async () => {
+    if (
+      !window.confirm(
+        "회원 탈퇴 시 계정과 연결된 정보가 삭제되며 되돌릴 수 없습니다. 탈퇴할까요?",
+      )
+    ) {
+      return;
+    }
+    try {
+      await settingService.withdraw(api);
+      await bridge.withdraw();
+      navigate("/auth", { replace: true });
+    } catch {
+      setStatus("회원 탈퇴에 실패했습니다.");
+    }
+  };
+
+  return (
+    <main className="feature-page">
+      <header className="feature-page__header">
+        <div>
+          <span className="feature-page__eyebrow">내 앱 관리</span>
+          <h1>설정</h1>
+          <p>계정, 화면, 권한과 자동 전송 상태를 관리하세요.</p>
+        </div>
+      </header>
+      {status && <p aria-live="polite">{status}</p>}
+
+      <SettingSection title="계정">
+        <li>
+          <button
+            className="setting-item"
+            onClick={() => void editNickname()}
+            type="button"
+          >
+            <span className="setting-profile">
+              <strong>{me?.nickname ?? "내 정보"}</strong>
+              <span>{me?.email ?? "계정 정보를 확인하는 중"}</span>
+            </span>
+            <span className="setting-item__detail">닉네임 수정</span>
+          </button>
+        </li>
+      </SettingSection>
+
+      <SettingSection title="디스플레이">
+        <li>
+          <button className="setting-item" onClick={toggleTheme} type="button">
+            <span>화면 테마</span>
+            <span className="setting-item__detail">
+              {theme === "dark" ? "다크" : "라이트"}
+            </span>
+          </button>
+        </li>
+      </SettingSection>
+
+      <SettingSection title="앱 사용 권한">
+        <PermissionItem
+          granted={readiness?.notification ?? false}
+          label="앱 알림 권한"
+          onClick={() =>
+            void openPermission(
+              "notification",
+              readiness?.notification ?? false,
+            )
+          }
+        />
+        <PermissionItem
+          granted={readiness?.locationAlways ?? false}
+          label="항상 위치 권한"
+          onClick={() =>
+            void openPermission(
+              "locationAlways",
+              readiness?.locationAlways ?? false,
+            )
+          }
+        />
+        <PermissionItem
+          granted={readiness?.batteryOptimization ?? false}
+          label="배터리 최적화 제외"
+          onClick={() =>
+            void openPermission(
+              "batteryOptimization",
+              readiness?.batteryOptimization ?? false,
+            )
+          }
+        />
+        <PermissionItem
+          granted={contactAccess}
+          label="연락처 접근 권한"
+          onClick={() =>
+            void bridge
+              .getDeviceContacts()
+              .then(() => setContactAccess(true))
+              .catch(() => setStatus("연락처 권한을 확인하지 못했습니다."))
+          }
+        />
+      </SettingSection>
+
+      <SettingSection title="전송 진단">
+        <li>
+          <Link className="setting-item" to="/record/send-history">
+            <span>마지막 자동 전송</span>
+            <span className="setting-item__detail">
+              {lastRecord
+                ? `${lastRecord.geofenceName} · ${formatActivityTime(lastRecord.occurredAt)}`
+                : "아직 없음"}
+            </span>
+          </Link>
+        </li>
+        <li>
+          <p className="setting-note">
+            일부 기기의 제조사 절전 설정은 자동 전송을 막을 수 있습니다. 전송이
+            누락되면 절전 설정에서 ImHere를 제외해 주세요.
+          </p>
+        </li>
+      </SettingSection>
+
+      <SettingSection title="서비스 약관">
+        {terms.length === 0 ? (
+          <li>
+            <span className="setting-item">표시할 약관이 없습니다.</span>
+          </li>
+        ) : (
+          terms.map((term) => (
+            <li key={term.id}>
+              <Link className="setting-item" to={`/terms-detail/${term.id}`}>
+                <span>{term.title}</span>
+                <span className="setting-item__detail">보기</span>
+              </Link>
+            </li>
+          ))
+        )}
+      </SettingSection>
+
+      <SettingSection title="고객 지원">
+        <li>
+          <button
+            className="setting-item"
+            onClick={() =>
+              void bridge
+                .openExternalUrl({ url: SUPPORT_URL })
+                .catch(() => setStatus("문의하기 페이지를 열지 못했습니다."))
+            }
+            type="button"
+          >
+            <span>문의하기</span>
+            <span className="setting-item__detail">Notion</span>
+          </button>
+        </li>
+      </SettingSection>
+
+      <SettingSection title="앱 정보">
+        <li>
+          <span className="setting-item">
+            <span>버전 정보</span>
+            <span className="setting-item__detail">
+              {appInfo
+                ? `${appInfo.appVersion} (${appInfo.buildNumber})`
+                : "정보 없음"}
+            </span>
+          </span>
+        </li>
+      </SettingSection>
+
+      <footer className="setting-footer">
+        <p>ImHere · 소중한 사람과 위치의 순간을 나눠요.</p>
+        <button
+          className="ds-button ds-button--secondary"
+          onClick={() => void signOut()}
+          type="button"
+        >
+          로그아웃
+        </button>
+        <button
+          className="ds-button ds-button--danger"
+          onClick={() => void withdraw()}
+          type="button"
+        >
+          회원 탈퇴
+        </button>
+      </footer>
+    </main>
+  );
+}
+
+function SettingSection({
+  title,
+  children,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <section className="setting-section">
+      <h2>{title}</h2>
+      <ul className="setting-list">{children}</ul>
+    </section>
+  );
+}
+
+function PermissionItem({
+  label,
+  granted,
+  onClick,
+}: {
+  granted: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <li>
+      <button className="setting-item" onClick={onClick} type="button">
+        <span>{label}</span>
+        <span className="setting-item__detail">
+          {granted ? "허용됨" : "설정 필요"}
+        </span>
+      </button>
+    </li>
+  );
 }

--- a/web/src/pages/setting/setting-service.ts
+++ b/web/src/pages/setting/setting-service.ts
@@ -1,0 +1,30 @@
+import type { ApiClient } from "@/api/api-client";
+
+export interface UserMe {
+  email: string;
+  id: string;
+  isActive?: boolean;
+  nickname: string;
+  oAuth2Provider: string;
+  userStatus?: string;
+}
+
+export const settingService = {
+  me(api: ApiClient) {
+    return api.request<UserMe>("/api/users/my");
+  },
+  changeNickname(api: ApiClient, nickname: string) {
+    return api.request<UserMe>("/api/users/my", {
+      method: "PATCH",
+      body: JSON.stringify({ nickname }),
+    });
+  },
+  withdraw(api: ApiClient) {
+    return api.request<void>("/api/users/my/withdrawal", {
+      method: "DELETE",
+    });
+  },
+};
+
+export const SUPPORT_URL =
+  "https://dsko.notion.site/37c2776ec1898041b254ee2870657dcc?pvs=105";

--- a/web/src/pages/setting/setting.css
+++ b/web/src/pages/setting/setting.css
@@ -1,0 +1,85 @@
+.setting-section {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.setting-section > h2 {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-body-medium);
+}
+
+.setting-list {
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  list-style: none;
+}
+
+.setting-item {
+  display: flex;
+  min-height: var(--touch-target-min);
+  gap: var(--space-4);
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-4);
+  border: 0;
+  border-bottom: 1px solid var(--color-divider);
+  color: var(--color-text);
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  text-decoration: none;
+}
+
+.setting-list > :last-child .setting-item,
+.setting-list > .setting-item:last-child {
+  border-bottom: 0;
+}
+
+button.setting-item {
+  cursor: pointer;
+}
+
+.setting-item__detail {
+  color: var(--color-text-secondary);
+  text-align: right;
+}
+
+.setting-profile {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.setting-profile strong {
+  font-size: var(--text-headline-small);
+}
+
+.setting-profile span {
+  color: var(--color-text-secondary);
+}
+
+.setting-note {
+  padding: var(--space-4);
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-body-small);
+  line-height: var(--line-body-medium);
+}
+
+.setting-footer {
+  display: grid;
+  gap: var(--space-3);
+  justify-items: center;
+  padding: var(--space-6) 0;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.setting-footer p {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- add account profile and nickname editing through /api/users/my
- synchronize native theme events, React tokens, and status-bar style
- add permission controls, native delivery diagnostics, active terms, Notion support, and app version
- add bridge-backed sign-out and API/native account withdrawal
- complete F09 iOS geofence capacity/one-shot guidance and F11 native record deletion
- add accessibility and native-theme synchronization tests

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test (17 files, 56 tests)
- pnpm build

Closes #92