### PR TITLE
feat: add isolated React landing experience

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="../src/main.tsx"></script>
   </body>
 </html>

--- a/web/landing/index.html
+++ b/web/landing/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta
+      name="description"
+      content="서로 수락한 친구의 출발과 도착 순간만 알려주는 위치 안심 알림 서비스 ImHere."
+    />
+    <meta name="theme-color" content="#0071e3" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ko_KR" />
+    <meta property="og:site_name" content="ImHere" />
+    <meta property="og:title" content="ImHere | 위치 기반 서비스" />
+    <meta
+      property="og:description"
+      content="서로 수락한 친구의 출발과 도착 순간만 알려주는 위치 안심 알림 서비스 ImHere."
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="ImHere | 위치 기반 서비스" />
+    <meta
+      name="twitter:description"
+      content="서로 수락한 친구의 출발과 도착 순간만 알려주는 위치 안심 알림 서비스 ImHere."
+    />
+    <link rel="canonical" href="https://imhere.ratiko.co.kr/" />
+    <link rel="icon" href="data:," />
+    <title>ImHere | 위치 기반 서비스</title>
+  </head>
+  <body>
+    <div id="landing-root"></div>
+    <script type="module" src="../src/landing/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,13 @@
   "scripts": {
     "bridge:check": "tsx packages/bridge-contract/scripts/generate-dart.ts --check",
     "bridge:generate": "tsx packages/bridge-contract/scripts/generate-dart.ts",
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "vite --config vite.app.config.ts",
+    "dev:app": "vite --config vite.app.config.ts",
+    "dev:landing": "vite --config vite.landing.config.ts",
+    "build": "pnpm typecheck && pnpm build:app && pnpm build:landing && pnpm check:build-isolation",
+    "build:app": "vite build --config vite.app.config.ts",
+    "build:landing": "vite build --config vite.landing.config.ts",
+    "check:build-isolation": "node scripts/check-build-isolation.mjs",
     "check:tokens": "node scripts/check-color-tokens.mjs",
     "font:subset": "node scripts/subset-gmarket-font.mjs",
     "lint": "eslint . --max-warnings 0 && node scripts/check-color-tokens.mjs",
@@ -29,7 +34,8 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-i18next": "17.0.11",
-    "react-router-dom": "7.18.1"
+    "react-router-dom": "7.18.1",
+    "three": "0.178.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
@@ -40,6 +46,7 @@
     "@types/node": "22.18.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "@types/three": "0.178.1",
     "@vitejs/plugin-react": "6.0.4",
     "@vitest/coverage-v8": "4.1.10",
     "axe-core": "4.12.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-router-dom:
         specifier: 7.18.1
         version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      three:
+        specifier: 0.178.0
+        version: 0.178.0
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -57,6 +60,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/three':
+        specifier: 0.178.1
+        version: 0.178.1
       '@vitejs/plugin-react':
         specifier: 6.0.4
         version: 6.0.4(vite@8.1.5(@types/node@22.18.0)(esbuild@0.28.1)(tsx@4.23.1))
@@ -243,6 +249,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -642,6 +651,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -673,6 +685,15 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.178.1':
+    resolution: {integrity: sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -783,6 +804,9 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1008,6 +1032,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1263,6 +1290,9 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  meshoptimizer@0.18.1:
+    resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1461,6 +1491,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  three@0.178.0:
+    resolution: {integrity: sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1843,6 +1876,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -2112,6 +2147,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -2143,6 +2180,20 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.178.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.71
+      fflate: 0.8.3
+      meshoptimizer: 0.18.1
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
@@ -2294,6 +2345,8 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@webgpu/types@0.1.71': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -2532,6 +2585,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -2747,6 +2802,8 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  meshoptimizer@0.18.1: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -2920,6 +2977,8 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
+
+  three@0.178.0: {}
 
   tinybench@2.9.0: {}
 

--- a/web/scripts/check-build-isolation.mjs
+++ b/web/scripts/check-build-isolation.mjs
@@ -1,0 +1,90 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const webRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const appRoot = path.join(webRoot, "dist", "app");
+const landingRoot = path.join(webRoot, "dist", "landing");
+
+async function collectFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(entryPath)));
+    } else {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+async function readManifest(root) {
+  return JSON.parse(
+    await readFile(path.join(root, ".vite", "manifest.json"), "utf8"),
+  );
+}
+
+const [appManifest, landingManifest, appFiles, landingFiles] =
+  await Promise.all([
+    readManifest(appRoot),
+    readManifest(landingRoot),
+    collectFiles(appRoot),
+    collectFiles(landingRoot),
+  ]);
+
+const appGraph = JSON.stringify(appManifest).toLowerCase();
+if (appGraph.includes("landing") || appGraph.includes("three")) {
+  throw new Error(
+    "The app build manifest references landing or Three.js code.",
+  );
+}
+
+const appSource = (
+  await Promise.all(
+    appFiles
+      .filter((file) => /\.(html|js|css|json)$/.test(file))
+      .map((file) => readFile(file, "utf8")),
+  )
+).join("\n");
+
+for (const marker of ["철수에게 귀가 알림", "threejourney", "webglrenderer"]) {
+  if (appSource.toLowerCase().includes(marker.toLowerCase())) {
+    throw new Error(`The app build contains a landing marker: ${marker}`);
+  }
+}
+
+const appHtml = await readFile(path.join(appRoot, "index.html"), "utf8");
+if (!appHtml.includes("/app/assets/")) {
+  throw new Error("The app build is not rooted at /app/.");
+}
+
+const landingHtml = await readFile(
+  path.join(landingRoot, "index.html"),
+  "utf8",
+);
+if (!landingHtml.includes("/assets/")) {
+  throw new Error("The landing build is not rooted at the domain root.");
+}
+
+const landingSource = (
+  await Promise.all(
+    landingFiles
+      .filter((file) => /\.(html|js|css|json)$/.test(file))
+      .map((file) => readFile(file, "utf8")),
+  )
+).join("\n");
+if (
+  landingManifest["index.html"]?.isEntry !== true ||
+  !landingSource.toLowerCase().includes("webgl")
+) {
+  throw new Error("The landing build does not contain its 3D journey.");
+}
+
+console.log("Landing and app build isolation check passed.");

--- a/web/src/design-system/tokens.css
+++ b/web/src/design-system/tokens.css
@@ -65,6 +65,21 @@
   --color-primary-soft: rgb(0 113 227 / 10%);
   --color-error-soft: rgb(255 59 48 / 12%);
   --color-success-soft: rgb(52 199 89 / 12%);
+  --color-landing-sky: #e8f4ff;
+  --color-landing-map: #e7ecf2;
+  --color-landing-road: #ffffff;
+  --color-landing-building: #c7d2df;
+  --color-landing-building-accent: #9fb4ca;
+  --color-landing-park: #bfe7cc;
+  --color-landing-route: #0071e3;
+  --color-landing-person: #ff8a65;
+  --color-landing-grid: #c9d2dc;
+  --color-landing-water: #a9d5eb;
+  --color-landing-hill: #76aa78;
+  --color-landing-avatar: #6759bd;
+  --color-landing-amber: #f3a722;
+  --color-landing-rubber: #202832;
+  --color-landing-glow: rgb(0 113 227 / 22%);
   --shadow-card: 0 0.75rem 2.5rem rgb(29 29 31 / 8%);
   --shadow-sheet: 0 -1rem 3rem rgb(29 29 31 / 16%);
 }
@@ -88,6 +103,21 @@
   --color-primary-soft: rgb(10 132 255 / 16%);
   --color-error-soft: rgb(255 69 58 / 16%);
   --color-success-soft: rgb(48 209 88 / 16%);
+  --color-landing-sky: #101820;
+  --color-landing-map: #1c2833;
+  --color-landing-road: #3a4652;
+  --color-landing-building: #455565;
+  --color-landing-building-accent: #637a91;
+  --color-landing-park: #24543a;
+  --color-landing-route: #0a84ff;
+  --color-landing-person: #ff9f7e;
+  --color-landing-grid: #354453;
+  --color-landing-water: #285e78;
+  --color-landing-hill: #315f3d;
+  --color-landing-avatar: #8f83e6;
+  --color-landing-amber: #ffc04d;
+  --color-landing-rubber: #0d1117;
+  --color-landing-glow: rgb(10 132 255 / 28%);
   --shadow-card: 0 0.75rem 2.5rem rgb(0 0 0 / 36%);
   --shadow-sheet: 0 -1rem 3rem rgb(0 0 0 / 48%);
 }

--- a/web/src/landing/JourneyMap.tsx
+++ b/web/src/landing/JourneyMap.tsx
@@ -1,0 +1,724 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import {
+  AmbientLight,
+  BoxGeometry,
+  BufferGeometry,
+  CircleGeometry,
+  Color,
+  CurvePath,
+  CylinderGeometry,
+  DirectionalLight,
+  DoubleSide,
+  Group,
+  Line,
+  LineCurve3,
+  LineDashedMaterial,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  PlaneGeometry,
+  Scene,
+  SphereGeometry,
+  Vector3,
+  WebGLRenderer,
+} from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import {
+  CSS2DObject,
+  CSS2DRenderer,
+} from "three/examples/jsm/renderers/CSS2DRenderer.js";
+
+import type { DestinationId } from "@/landing/landing-flow";
+
+export type JourneyMapHandle = {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetView: () => void;
+  resetRoute: () => void;
+};
+
+type JourneyMapProps = {
+  destination: DestinationId;
+  radius: number;
+  friendAccepted: boolean;
+  running: boolean;
+  speed: number;
+  onProgress: (progress: number) => void;
+  onDeparture: () => void;
+  onArrival: () => void;
+};
+
+type MapController = JourneyMapHandle & {
+  setDestination: (destination: DestinationId) => void;
+  setRadius: (radius: number) => void;
+  setFriendAccepted: (accepted: boolean) => void;
+};
+
+type PlaceDefinition = {
+  label: string;
+  position: [number, number, number];
+  colorToken: string;
+};
+
+const places: Record<"start" | DestinationId, PlaceDefinition> = {
+  start: {
+    label: "광화문 출발 지점",
+    position: [-15, 0, 2.5],
+    colorToken: "--color-landing-amber",
+  },
+  cityhall: {
+    label: "서울 시청",
+    position: [5, 0, -6],
+    colorToken: "--color-primary",
+  },
+  station: {
+    label: "서울역",
+    position: [-5, 0, -14],
+    colorToken: "--color-success",
+  },
+  terminal: {
+    label: "고속 버스 터미널",
+    position: [5, 0, 12],
+    colorToken: "--color-error",
+  },
+};
+
+const routeCoordinates: Record<DestinationId, Array<[number, number]>> = {
+  cityhall: [
+    [-15, 2.5],
+    [5, 2.5],
+    [5, -6],
+  ],
+  station: [
+    [-15, 2.5],
+    [-5, 2.5],
+    [-5, -14],
+  ],
+  terminal: [
+    [-15, 2.5],
+    [5, 2.5],
+    [5, 12],
+  ],
+};
+
+function readColorToken(name: string) {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
+function tokenColor(name: string) {
+  return new Color(readColorToken(name));
+}
+
+function createBuilding(
+  width: number,
+  height: number,
+  depth: number,
+  x: number,
+  z: number,
+  accent = false,
+) {
+  const building = new Mesh(
+    new BoxGeometry(width, height, depth),
+    new MeshStandardMaterial({
+      color: tokenColor(
+        accent ? "--color-landing-building-accent" : "--color-landing-building",
+      ),
+      roughness: 0.84,
+    }),
+  );
+  building.position.set(x, height / 2, z);
+  return building;
+}
+
+function addRoad(
+  scene: Scene,
+  x: number,
+  z: number,
+  length: number,
+  width: number,
+  rotation: number,
+) {
+  const road = new Mesh(
+    new PlaneGeometry(length, width),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-road"),
+      roughness: 0.94,
+    }),
+  );
+  road.rotation.x = -Math.PI / 2;
+  road.rotation.z = rotation;
+  road.position.set(x, 0.03, z);
+  scene.add(road);
+
+  const dashCount = Math.floor(length / 3);
+  for (let index = 0; index < dashCount; index += 1) {
+    const dash = new Mesh(
+      new BoxGeometry(1.2, 0.025, 0.08),
+      new MeshBasicMaterial({ color: tokenColor("--color-landing-grid") }),
+    );
+    dash.position.set(-length / 2 + 1.5 + index * 3, 0.06, 0);
+    road.add(dash);
+  }
+}
+
+function addCity(scene: Scene) {
+  const ground = new Mesh(
+    new PlaneGeometry(56, 44),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-map"),
+      roughness: 1,
+    }),
+  );
+  ground.rotation.x = -Math.PI / 2;
+  scene.add(ground);
+
+  addRoad(scene, 0, 2.5, 48, 3.5, 0);
+  addRoad(scene, -5, -3, 32, 3.2, Math.PI / 2);
+  addRoad(scene, 5, 5, 29, 3.2, Math.PI / 2);
+
+  const park = new Mesh(
+    new PlaneGeometry(10, 7),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-park"),
+      roughness: 1,
+    }),
+  );
+  park.rotation.x = -Math.PI / 2;
+  park.position.set(0, 0.045, 10);
+  scene.add(park);
+
+  const river = new Mesh(
+    new PlaneGeometry(58, 5),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-water"),
+      roughness: 0.55,
+    }),
+  );
+  river.rotation.x = -Math.PI / 2;
+  river.position.set(0, 0.02, -19);
+  scene.add(river);
+
+  const buildingData = [
+    [-19, -8, 4, 6, 4, false],
+    [-14, -7, 3.5, 8, 3.5, true],
+    [-10, 9, 4, 5, 4, false],
+    [-2, -7, 4.5, 9, 4, true],
+    [4, -7, 4, 6, 4, false],
+    [12, -10, 5, 10, 4.5, true],
+    [17, -3, 4, 7, 4, false],
+    [13, 7, 4.5, 5, 4, true],
+    [18, 12, 4, 8, 4, false],
+    [-17, 13, 5, 7, 4.5, true],
+  ] as const;
+  for (const [x, z, width, height, depth, accent] of buildingData) {
+    scene.add(createBuilding(width, height, depth, x, z, accent));
+  }
+
+  const hill = new Mesh(
+    new CylinderGeometry(3.2, 4.5, 1.2, 32),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-hill"),
+      roughness: 1,
+    }),
+  );
+  hill.position.set(20, 0.55, 18);
+  scene.add(hill);
+
+  const tower = new Group();
+  const towerMaterial = new MeshStandardMaterial({
+    color: tokenColor("--color-surface"),
+    roughness: 0.65,
+  });
+  const towerBody = new Mesh(
+    new CylinderGeometry(0.3, 0.55, 5.5, 14),
+    towerMaterial,
+  );
+  towerBody.position.y = 3.4;
+  const observatory = new Mesh(
+    new CylinderGeometry(0.9, 0.7, 0.8, 18),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-building-accent"),
+      roughness: 0.45,
+    }),
+  );
+  observatory.position.y = 5.9;
+  tower.add(towerBody, observatory);
+  tower.position.set(20, 0.7, 18);
+  scene.add(tower);
+}
+
+function createPlaceMarker(
+  id: "start" | DestinationId,
+  definition: PlaceDefinition,
+) {
+  const marker = new Group();
+  marker.position.set(...definition.position);
+  const color = tokenColor(definition.colorToken);
+  const base = new Mesh(
+    new CylinderGeometry(0.8, 0.8, 0.12, 28),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-surface"),
+      roughness: 0.8,
+    }),
+  );
+  base.position.y = 0.06;
+  const pole = new Mesh(
+    new CylinderGeometry(0.07, 0.07, 0.8, 12),
+    new MeshStandardMaterial({ color }),
+  );
+  pole.position.y = 0.5;
+  const pin = new Mesh(
+    new SphereGeometry(0.28, 18, 18),
+    new MeshStandardMaterial({ color, roughness: 0.5 }),
+  );
+  pin.position.y = 0.98;
+  marker.add(base, pole, pin);
+
+  const labelElement = document.createElement("div");
+  labelElement.className = "map-place-label";
+  labelElement.dataset.place = id;
+  labelElement.textContent = definition.label;
+  const label = new CSS2DObject(labelElement);
+  label.position.set(0, 1.65, 0);
+  marker.add(label);
+  return { marker, labelElement };
+}
+
+function createCar() {
+  const car = new Group();
+  const bodyMaterial = new MeshStandardMaterial({
+    color: tokenColor("--color-primary"),
+    roughness: 0.48,
+  });
+  const body = new Mesh(new BoxGeometry(1.25, 0.45, 2.1), bodyMaterial);
+  body.position.y = 0.5;
+  const cabin = new Mesh(
+    new BoxGeometry(1.05, 0.55, 1),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-building-accent"),
+      roughness: 0.35,
+    }),
+  );
+  cabin.position.set(0, 0.93, -0.08);
+  car.add(body, cabin);
+
+  const wheelMaterial = new MeshStandardMaterial({
+    color: tokenColor("--color-landing-rubber"),
+    roughness: 0.9,
+  });
+  const wheels: Mesh[] = [];
+  for (const x of [-0.7, 0.7]) {
+    for (const z of [-0.65, 0.65]) {
+      const wheel = new Mesh(
+        new CylinderGeometry(0.24, 0.24, 0.18, 16),
+        wheelMaterial,
+      );
+      wheel.rotation.z = Math.PI / 2;
+      wheel.position.set(x, 0.3, z);
+      wheels.push(wheel);
+      car.add(wheel);
+    }
+  }
+  car.userData.wheels = wheels;
+
+  const driver = new Mesh(
+    new SphereGeometry(0.2, 16, 16),
+    new MeshStandardMaterial({
+      color: tokenColor("--color-landing-person"),
+      roughness: 0.7,
+    }),
+  );
+  driver.position.set(0, 1.34, 0.1);
+  car.add(driver);
+
+  const nameElement = document.createElement("div");
+  nameElement.className = "map-runner-label";
+  nameElement.textContent = "철수";
+  const nameLabel = new CSS2DObject(nameElement);
+  nameLabel.position.set(0, 2, 0);
+  car.add(nameLabel);
+  return car;
+}
+
+function createRoute(destination: DestinationId) {
+  const points = routeCoordinates[destination].map(
+    ([x, z]) => new Vector3(x, 0.14, z),
+  );
+  const route = new CurvePath<Vector3>();
+  for (let index = 1; index < points.length; index += 1) {
+    route.add(new LineCurve3(points[index - 1], points[index]));
+  }
+  return route;
+}
+
+export const JourneyMap = forwardRef<JourneyMapHandle, JourneyMapProps>(
+  function JourneyMap(
+    {
+      destination,
+      radius,
+      friendAccepted,
+      running,
+      speed,
+      onProgress,
+      onDeparture,
+      onArrival,
+    },
+    forwardedRef,
+  ) {
+    const hostRef = useRef<HTMLDivElement>(null);
+    const controllerRef = useRef<MapController | null>(null);
+    const propsRef = useRef({
+      running,
+      speed,
+      onProgress,
+      onDeparture,
+      onArrival,
+    });
+    const initialSettingsRef = useRef({
+      destination,
+      radius,
+      friendAccepted,
+    });
+    const [webGlFailed, setWebGlFailed] = useState(false);
+
+    useEffect(() => {
+      propsRef.current = {
+        running,
+        speed,
+        onProgress,
+        onDeparture,
+        onArrival,
+      };
+    }, [onArrival, onDeparture, onProgress, running, speed]);
+
+    useImperativeHandle(
+      forwardedRef,
+      () => ({
+        zoomIn: () => controllerRef.current?.zoomIn(),
+        zoomOut: () => controllerRef.current?.zoomOut(),
+        resetView: () => controllerRef.current?.resetView(),
+        resetRoute: () => controllerRef.current?.resetRoute(),
+      }),
+      [],
+    );
+
+    useEffect(() => {
+      controllerRef.current?.setDestination(destination);
+    }, [destination]);
+
+    useEffect(() => {
+      controllerRef.current?.setRadius(radius);
+    }, [radius]);
+
+    useEffect(() => {
+      controllerRef.current?.setFriendAccepted(friendAccepted);
+    }, [friendAccepted]);
+
+    useEffect(() => {
+      const host = hostRef.current;
+      if (host === null) return;
+
+      let renderer: WebGLRenderer;
+      try {
+        renderer = new WebGLRenderer({
+          antialias: true,
+          powerPreference: "high-performance",
+        });
+      } catch {
+        const fallbackTimer = window.setTimeout(() => setWebGlFailed(true), 0);
+        return () => window.clearTimeout(fallbackTimer);
+      }
+
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5));
+      renderer.outputColorSpace = "srgb";
+      renderer.domElement.setAttribute("aria-hidden", "true");
+      host.append(renderer.domElement);
+
+      const labelRenderer = new CSS2DRenderer();
+      labelRenderer.domElement.className = "map-label-layer";
+      host.append(labelRenderer.domElement);
+
+      const scene = new Scene();
+      scene.background = tokenColor("--color-landing-sky");
+      addCity(scene);
+      scene.add(new AmbientLight(tokenColor("--color-surface"), 2.1));
+      const sun = new DirectionalLight(tokenColor("--color-surface"), 3.1);
+      sun.position.set(-12, 28, 18);
+      scene.add(sun);
+
+      const camera = new PerspectiveCamera(38, 1, 0.1, 140);
+      const resetCamera = () => {
+        camera.position.set(25, 30, 34);
+        controls.target.set(0, 0, 0);
+        controls.update();
+      };
+      const controls = new OrbitControls(camera, renderer.domElement);
+      controls.enableDamping = true;
+      controls.dampingFactor = 0.07;
+      controls.minDistance = 22;
+      controls.maxDistance = 65;
+      controls.maxPolarAngle = Math.PI * 0.47;
+      resetCamera();
+
+      const labelElements: Partial<
+        Record<"start" | DestinationId, HTMLDivElement>
+      > = {};
+      for (const [id, definition] of Object.entries(places) as Array<
+        ["start" | DestinationId, PlaceDefinition]
+      >) {
+        const { marker, labelElement } = createPlaceMarker(id, definition);
+        scene.add(marker);
+        labelElements[id] = labelElement;
+      }
+
+      const car = createCar();
+      scene.add(car);
+
+      const accuracyRing = new Mesh(
+        new CircleGeometry(1.25, 40),
+        new MeshBasicMaterial({
+          color: tokenColor("--color-primary"),
+          transparent: true,
+          opacity: 0.15,
+          side: DoubleSide,
+          depthWrite: false,
+        }),
+      );
+      accuracyRing.rotation.x = -Math.PI / 2;
+      scene.add(accuracyRing);
+
+      const destinationRing = new Mesh(
+        new CircleGeometry(1.7, 48),
+        new MeshBasicMaterial({
+          color: tokenColor("--color-primary"),
+          transparent: true,
+          opacity: 0.38,
+          side: DoubleSide,
+          depthWrite: false,
+        }),
+      );
+      destinationRing.rotation.x = -Math.PI / 2;
+      scene.add(destinationRing);
+
+      let activeDestination = initialSettingsRef.current.destination;
+      let route = createRoute(activeDestination);
+      let routeLine: Line | null = null;
+      let progress = 0;
+      let departureSent = false;
+      let arrivalSent = false;
+      let lastReportedPercent = -1;
+
+      const renderRoute = () => {
+        if (routeLine !== null) {
+          scene.remove(routeLine);
+          routeLine.geometry.dispose();
+          if (Array.isArray(routeLine.material)) {
+            routeLine.material.forEach((material) => material.dispose());
+          } else {
+            routeLine.material.dispose();
+          }
+        }
+        const geometry = new BufferGeometry().setFromPoints(
+          route.getPoints(90),
+        );
+        const material = new LineDashedMaterial({
+          color: tokenColor("--color-landing-route"),
+          dashSize: 0.55,
+          gapSize: 0.3,
+          transparent: true,
+          opacity: 0.9,
+        });
+        routeLine = new Line(geometry, material);
+        routeLine.computeLineDistances();
+        routeLine.visible = initialSettingsRef.current.friendAccepted;
+        scene.add(routeLine);
+      };
+
+      const placeCar = () => {
+        const point = route.getPointAt(progress);
+        const next = route.getPointAt(Math.min(1, progress + 0.01));
+        car.position.copy(point);
+        car.lookAt(next.x, point.y, next.z);
+        accuracyRing.position.set(point.x, 0.07, point.z);
+      };
+
+      const updateDestination = () => {
+        const destinationPlace = places[activeDestination];
+        destinationRing.position.set(
+          destinationPlace.position[0],
+          0.06,
+          destinationPlace.position[2],
+        );
+        Object.entries(labelElements).forEach(([id, element]) => {
+          element?.classList.toggle("is-selected", id === activeDestination);
+        });
+      };
+
+      const resetRoute = () => {
+        progress = 0;
+        departureSent = false;
+        arrivalSent = false;
+        lastReportedPercent = -1;
+        car.visible = true;
+        accuracyRing.visible = true;
+        placeCar();
+        resetCamera();
+        propsRef.current.onProgress(0);
+      };
+
+      renderRoute();
+      updateDestination();
+      destinationRing.scale.setScalar(
+        Math.max(0.85, initialSettingsRef.current.radius / 150),
+      );
+      placeCar();
+
+      controllerRef.current = {
+        zoomIn: () => {
+          camera.position.multiplyScalar(0.88);
+          controls.update();
+        },
+        zoomOut: () => {
+          camera.position.multiplyScalar(1.12);
+          controls.update();
+        },
+        resetView: resetCamera,
+        resetRoute,
+        setDestination: (nextDestination) => {
+          activeDestination = nextDestination;
+          route = createRoute(activeDestination);
+          resetRoute();
+          renderRoute();
+          updateDestination();
+        },
+        setRadius: (nextRadius) => {
+          destinationRing.scale.setScalar(Math.max(0.85, nextRadius / 150));
+        },
+        setFriendAccepted: (accepted) => {
+          if (routeLine !== null) routeLine.visible = accepted;
+          destinationRing.visible = accepted;
+        },
+      };
+
+      destinationRing.visible = initialSettingsRef.current.friendAccepted;
+
+      const resize = () => {
+        const width = host.clientWidth;
+        const height = host.clientHeight;
+        renderer.setSize(width, height, false);
+        labelRenderer.setSize(width, height);
+        camera.aspect = width / Math.max(height, 1);
+        camera.updateProjectionMatrix();
+      };
+      const resizeObserver = new ResizeObserver(resize);
+      resizeObserver.observe(host);
+      resize();
+
+      let previousTime = performance.now();
+      let animationFrame = 0;
+      const point = new Vector3();
+      const next = new Vector3();
+      const desiredFollowTarget = new Vector3();
+      const desiredCameraPosition = new Vector3();
+      const travelDirection = new Vector3();
+      const animate = (now: number) => {
+        const delta = Math.min(Math.max((now - previousTime) / 1000, 0), 0.05);
+        previousTime = now;
+
+        if (propsRef.current.running && progress < 1) {
+          progress = Math.min(
+            1,
+            progress + delta * 0.052 * propsRef.current.speed,
+          );
+          route.getPointAt(progress, point);
+          route.getPointAt(Math.min(1, progress + 0.006), next);
+          car.position.copy(point);
+          car.lookAt(next.x, point.y, next.z);
+          accuracyRing.position.set(point.x, 0.07, point.z);
+          travelDirection.copy(next).sub(point).normalize();
+          desiredFollowTarget
+            .set(point.x, 0.8, point.z)
+            .addScaledVector(travelDirection, 2.2);
+          desiredCameraPosition
+            .set(point.x, 5.2, point.z)
+            .addScaledVector(travelDirection, -7.2);
+          const followAmount = 1 - Math.exp(-delta * 3.8);
+          controls.target.lerp(desiredFollowTarget, followAmount);
+          camera.position.lerp(desiredCameraPosition, followAmount);
+          camera.lookAt(controls.target);
+          accuracyRing.rotation.z += delta * 0.45;
+          for (const wheel of car.userData.wheels as Mesh[]) {
+            wheel.rotation.x -= delta * 8 * propsRef.current.speed;
+          }
+
+          const percent = Math.round(progress * 100);
+          if (percent - lastReportedPercent >= 2 || percent === 100) {
+            lastReportedPercent = percent;
+            propsRef.current.onProgress(progress);
+          }
+          if (progress >= 0.08 && !departureSent) {
+            departureSent = true;
+            propsRef.current.onDeparture();
+          }
+          if (progress >= 1 && !arrivalSent) {
+            arrivalSent = true;
+            car.visible = false;
+            accuracyRing.visible = false;
+            propsRef.current.onArrival();
+          }
+        }
+
+        const ringMaterial = destinationRing.material;
+        if (ringMaterial instanceof MeshBasicMaterial) {
+          ringMaterial.opacity = 0.38 + Math.sin(now * 0.003) * 0.12;
+        }
+        controls.enabled = !propsRef.current.running;
+        if (controls.enabled) controls.update();
+        renderer.render(scene, camera);
+        labelRenderer.render(scene, camera);
+        animationFrame = requestAnimationFrame(animate);
+      };
+      animationFrame = requestAnimationFrame(animate);
+
+      return () => {
+        cancelAnimationFrame(animationFrame);
+        resizeObserver.disconnect();
+        controls.dispose();
+        controllerRef.current = null;
+        scene.traverse((object) => {
+          if (object instanceof Mesh || object instanceof Line) {
+            object.geometry.dispose();
+            if (Array.isArray(object.material)) {
+              object.material.forEach((material) => material.dispose());
+            } else {
+              object.material.dispose();
+            }
+          }
+        });
+        renderer.dispose();
+        renderer.domElement.remove();
+        labelRenderer.domElement.remove();
+      };
+    }, []);
+
+    if (webGlFailed) {
+      return (
+        <div className="map-fallback" role="status">
+          <strong>3D 지도를 불러오지 못했어요</strong>
+          <span>WebGL을 지원하는 최신 브라우저에서 다시 열어 주세요.</span>
+        </div>
+      );
+    }
+
+    return <div ref={hostRef} className="journey-map" />;
+  },
+);

--- a/web/src/landing/LandingPage.tsx
+++ b/web/src/landing/LandingPage.tsx
@@ -1,0 +1,607 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+
+import { JourneyMap, type JourneyMapHandle } from "@/landing/JourneyMap";
+import {
+  destinationById,
+  destinations,
+  initialLandingFlowState,
+  landingFlowReducer,
+} from "@/landing/landing-flow";
+
+type DemoEvent = {
+  id: number;
+  type: "depart" | "arrive";
+  title: string;
+  message: string;
+  time: string;
+};
+
+type Toast = {
+  id: number;
+  type?: "arrive";
+  title: string;
+  message: string;
+};
+
+function InstallDialog({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="install-dialog-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        className="install-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="install-dialog-title"
+      >
+        <header>
+          <span>체험 완료</span>
+          <button
+            className="install-dialog__close"
+            type="button"
+            aria-label="설치 팝업 닫기"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </header>
+        <h2 id="install-dialog-title">ImHere 설치</h2>
+        <div className="download-actions">
+          <a
+            href="https://play.google.com/store/apps/details?id=com.kdongsu5509.iamhere"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span aria-hidden="true">▶</span>
+            <span>
+              <small>Google Play</small>
+              <strong>다운로드</strong>
+            </span>
+          </a>
+          <button type="button" disabled aria-label="App Store 출시 예정">
+            <span aria-hidden="true">●</span>
+            <span>
+              <small>App Store</small>
+              <strong>출시 예정</strong>
+            </span>
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function nowLabel() {
+  return new Intl.DateTimeFormat("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date());
+}
+
+export function LandingPage() {
+  const [flow, dispatch] = useReducer(
+    landingFlowReducer,
+    initialLandingFlowState,
+  );
+  const [departureEnabled, setDepartureEnabled] = useState(true);
+  const [arrivalEnabled, setArrivalEnabled] = useState(true);
+  const [events, setEvents] = useState<DemoEvent[]>([]);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [showDownload, setShowDownload] = useState(false);
+  const mapRef = useRef<JourneyMapHandle>(null);
+  const nextIdRef = useRef(1);
+  const destination = destinationById(flow.destination);
+
+  useEffect(() => {
+    if (!showDownload) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setShowDownload(false);
+    };
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", closeOnEscape);
+    window.setTimeout(() => {
+      document
+        .querySelector<HTMLButtonElement>(".install-dialog__close")
+        ?.focus();
+    }, 0);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [showDownload]);
+
+  const pushToast = useCallback(
+    (title: string, message: string, type?: "arrive") => {
+      const id = nextIdRef.current;
+      nextIdRef.current += 1;
+      setToasts([{ id, title, message, type }]);
+      window.setTimeout(() => {
+        setToasts((current) => current.filter((toast) => toast.id !== id));
+      }, 4_200);
+    },
+    [],
+  );
+
+  const addEvent = useCallback(
+    (type: DemoEvent["type"], title: string, message: string) => {
+      const id = nextIdRef.current;
+      nextIdRef.current += 1;
+      setEvents((current) => [
+        { id, type, title, message, time: nowLabel() },
+        ...current,
+      ]);
+      pushToast(title, message, type === "arrive" ? "arrive" : undefined);
+    },
+    [pushToast],
+  );
+
+  const acceptFriend = () => {
+    dispatch({ type: "accept-friend" });
+    pushToast("친구 연결", "철수 연결 완료");
+  };
+
+  const savePlace = () => {
+    dispatch({ type: "save-place" });
+    pushToast("장소 설정", `${destination.label} · ${flow.radius}m`);
+  };
+
+  const toggleRun = () => {
+    if (flow.progress >= 1) {
+      mapRef.current?.resetRoute();
+    }
+    dispatch({ type: "toggle-run" });
+    if (!flow.running) {
+      document
+        .querySelector(".map-stage")
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  };
+
+  const resetRoute = () => {
+    mapRef.current?.resetRoute();
+    dispatch({ type: "reset-route" });
+  };
+
+  const handleDeparture = useCallback(() => {
+    if (!departureEnabled) return;
+    addEvent("depart", "출발", "광화문");
+  }, [addEvent, departureEnabled]);
+
+  const handleArrival = useCallback(() => {
+    dispatch({ type: "arrive" });
+    if (arrivalEnabled) {
+      addEvent("arrive", "도착", `${destination.label} · ${flow.radius}m`);
+    }
+    pushToast("체험 완료", "앱에서 계속", "arrive");
+  }, [addEvent, arrivalEnabled, destination.label, flow.radius, pushToast]);
+
+  const liveStatus = useMemo(() => {
+    if (!flow.friendAccepted) return "친구 연결 전";
+    if (!flow.placeConfigured) return "장소 선택 전";
+    if (flow.progress >= 1) return `${destination.label} 도착`;
+    if (flow.running) return `${destination.label} 이동 중`;
+    if (flow.progress > 0) return "일시 정지";
+    return "출발 준비";
+  }, [
+    destination.label,
+    flow.friendAccepted,
+    flow.placeConfigured,
+    flow.progress,
+    flow.running,
+  ]);
+
+  const distanceLabel = useMemo(() => {
+    if (!flow.friendAccepted) return "대기 중";
+    if (!flow.placeConfigured) return "친구 연결됨";
+    if (flow.progress >= 1) return "도착";
+    if (flow.progress === 0) return "출발 전";
+    const totalDistance = flow.destination === "cityhall" ? 1_280 : 930;
+    const remaining = Math.max(
+      0,
+      Math.round((1 - flow.progress) * totalDistance),
+    );
+    return remaining >= 1_000
+      ? `${(remaining / 1_000).toFixed(1)}km 남음`
+      : `${remaining}m 남음`;
+  }, [
+    flow.destination,
+    flow.friendAccepted,
+    flow.placeConfigured,
+    flow.progress,
+  ]);
+
+  const progressWidth =
+    flow.step === "friend"
+      ? "33.333%"
+      : flow.step === "place"
+        ? "66.666%"
+        : "100%";
+
+  return (
+    <div className={flow.completed ? "landing is-complete" : "landing"}>
+      <header className="topbar">
+        <a className="brand" href="/" aria-label="ImHere 홈">
+          <strong>ImHere</strong>
+        </a>
+      </header>
+
+      <main>
+        <section className="product-intro" aria-labelledby="product-title">
+          <div>
+            <p className="eyebrow">위치 기반 서비스</p>
+            <h1 id="product-title">ImHere</h1>
+            <ul className="product-points">
+              <li>위치 기반</li>
+              <li>안심 귀가</li>
+              <li>자동 알림</li>
+            </ul>
+            <a className="product-cta" href="#experience">
+              체험
+              <span aria-hidden="true">↓</span>
+            </a>
+          </div>
+        </section>
+
+        <section
+          className="experience"
+          id="experience"
+          aria-labelledby="experience-title"
+        >
+          <header className="experience-heading">
+            <p className="eyebrow">3단계 체험</p>
+            <h2 id="experience-title">철수에게 귀가 알림을 보내보세요</h2>
+          </header>
+
+          <div className="workspace">
+            <aside className="panel setup-panel" aria-label="체험 설정">
+              <h3>알림 설정</h3>
+              <div className="progress-track" aria-hidden="true">
+                <div
+                  className="progress-fill"
+                  style={{ width: progressWidth }}
+                />
+              </div>
+
+              <section
+                className={`setup-step ${
+                  flow.step === "friend" ? "is-active" : "is-complete"
+                }`}
+              >
+                <span className="step-number">
+                  {flow.friendAccepted ? "✓" : "1"}
+                </span>
+                <h2>친구 연결</h2>
+                {flow.step === "friend" ? (
+                  <div className="step-body">
+                    <div className="request-card">
+                      <div className="request-person">
+                        <span className="friend-avatar">철</span>
+                        <span>
+                          <strong>철수</strong>
+                          <small>귀가 알림 요청</small>
+                        </span>
+                      </div>
+                      <div className="button-row">
+                        <button
+                          className="button button--quiet"
+                          type="button"
+                          onClick={() =>
+                            pushToast("친구 연결 필요", "수락 후 계속")
+                          }
+                        >
+                          나중에
+                        </button>
+                        <button
+                          className="button button--primary"
+                          type="button"
+                          onClick={acceptFriend}
+                        >
+                          수락하기
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <strong className="step-summary">철수와 연결되었어요</strong>
+                )}
+              </section>
+
+              <section
+                className={`setup-step ${
+                  flow.step === "place"
+                    ? "is-active"
+                    : flow.placeConfigured
+                      ? "is-complete"
+                      : ""
+                }`}
+              >
+                <span className="step-number">
+                  {flow.placeConfigured ? "✓" : "2"}
+                </span>
+                <h2>장소 선택</h2>
+                {flow.step === "place" ? (
+                  <div className="step-body">
+                    <div className="place-options" role="radiogroup">
+                      {destinations.map((place) => (
+                        <button
+                          key={place.id}
+                          className={
+                            flow.destination === place.id ? "is-selected" : ""
+                          }
+                          type="button"
+                          role="radio"
+                          aria-checked={flow.destination === place.id}
+                          onClick={() =>
+                            dispatch({
+                              type: "select-destination",
+                              destination: place.id,
+                            })
+                          }
+                        >
+                          <span aria-hidden="true">
+                            {place.id === "cityhall"
+                              ? "▦"
+                              : place.id === "station"
+                                ? "▣"
+                                : "▤"}
+                          </span>
+                          {place.shortLabel}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="setting-box">
+                      <label className="field-label" htmlFor="radius-range">
+                        <span>알림 반경</span>
+                        <strong>{flow.radius}m</strong>
+                      </label>
+                      <input
+                        id="radius-range"
+                        type="range"
+                        min="100"
+                        max="300"
+                        step="50"
+                        value={flow.radius}
+                        onChange={(event) =>
+                          dispatch({
+                            type: "set-radius",
+                            radius: Number(event.target.value),
+                          })
+                        }
+                      />
+                      <label className="check-row">
+                        <input
+                          type="checkbox"
+                          checked={departureEnabled}
+                          onChange={(event) =>
+                            setDepartureEnabled(event.target.checked)
+                          }
+                        />
+                        광화문 출발 알림 받기
+                      </label>
+                      <label className="check-row">
+                        <input
+                          type="checkbox"
+                          checked={arrivalEnabled}
+                          onChange={(event) =>
+                            setArrivalEnabled(event.target.checked)
+                          }
+                        />
+                        선택 장소 도착 알림 받기
+                      </label>
+                    </div>
+                    <button
+                      className="button button--primary button--wide"
+                      type="button"
+                      onClick={savePlace}
+                    >
+                      이 장소로 설정
+                    </button>
+                  </div>
+                ) : flow.placeConfigured ? (
+                  <strong className="step-summary">
+                    {destination.label} · 반경 {flow.radius}m
+                  </strong>
+                ) : null}
+              </section>
+
+              <section
+                className={`setup-step ${flow.step === "run" ? "is-active" : ""}`}
+              >
+                <span className="step-number">3</span>
+                <h2>귀가 시작</h2>
+                {flow.step === "run" && (
+                  <div className="step-body">
+                    <div className="simulation-actions">
+                      <button
+                        className="button button--primary"
+                        type="button"
+                        onClick={toggleRun}
+                      >
+                        <span aria-hidden="true">
+                          {flow.running ? "❚❚" : "▶"}
+                        </span>
+                        {flow.running ? "잠시 멈춤" : "이동 시작"}
+                      </button>
+                      <button
+                        className="button icon-button"
+                        type="button"
+                        aria-label="경로 처음부터"
+                        onClick={resetRoute}
+                      >
+                        ↻
+                      </button>
+                    </div>
+                    <div className="speed-control" aria-label="재생 속도">
+                      {[1, 2, 4].map((speed) => (
+                        <button
+                          key={speed}
+                          className={flow.speed === speed ? "is-selected" : ""}
+                          type="button"
+                          aria-pressed={flow.speed === speed}
+                          onClick={() => dispatch({ type: "set-speed", speed })}
+                        >
+                          {speed}×
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </section>
+            </aside>
+
+            <section
+              className="map-stage"
+              aria-label="철수의 이동 경로 3D 지도"
+            >
+              <JourneyMap
+                ref={mapRef}
+                destination={flow.destination}
+                radius={flow.radius}
+                friendAccepted={flow.friendAccepted}
+                running={flow.running}
+                speed={flow.speed}
+                onProgress={(progress) =>
+                  dispatch({ type: "set-progress", progress })
+                }
+                onDeparture={handleDeparture}
+                onArrival={handleArrival}
+              />
+              <div className="map-toolbar">
+                <div className="map-controls">
+                  <button
+                    type="button"
+                    aria-label="지도 확대"
+                    onClick={() => mapRef.current?.zoomIn()}
+                  >
+                    +
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="지도 축소"
+                    onClick={() => mapRef.current?.zoomOut()}
+                  >
+                    −
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="지도 위치 초기화"
+                    onClick={() => mapRef.current?.resetView()}
+                  >
+                    ⌖
+                  </button>
+                </div>
+              </div>
+              <div className="live-card" aria-live="polite">
+                <div className="live-head">
+                  <div className="live-person">
+                    <span className="friend-avatar">철</span>
+                    <span>
+                      <strong>철수</strong>
+                      <small>{liveStatus}</small>
+                    </span>
+                  </div>
+                  <strong className="live-distance">{distanceLabel}</strong>
+                </div>
+                <div
+                  className="route-progress"
+                  role="progressbar"
+                  aria-label="귀가 경로 진행률"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(flow.progress * 100)}
+                >
+                  <span style={{ width: `${flow.progress * 100}%` }} />
+                </div>
+              </div>
+              <span className="map-help">
+                드래그하여 회전 · 스크롤하여 확대
+              </span>
+            </section>
+
+            <aside className="panel activity-panel" aria-label="안심 알림 내역">
+              <div className="activity-head">
+                <h2>안심 알림</h2>
+                <button
+                  className="text-button"
+                  type="button"
+                  disabled={events.length === 0}
+                  onClick={() => setEvents([])}
+                >
+                  모두 지우기
+                </button>
+              </div>
+              {events.length === 0 ? (
+                <div className="empty-state">
+                  <span className="empty-icon" aria-hidden="true">
+                    ♢
+                  </span>
+                  <strong>아직 도착한 알림이 없어요</strong>
+                  <p>출발·도착 시 바로 알림</p>
+                </div>
+              ) : (
+                <ol className="timeline">
+                  {events.map((event) => (
+                    <li key={event.id} className="event">
+                      <span
+                        className={`event-icon ${
+                          event.type === "arrive" ? "is-arrival" : ""
+                        }`}
+                        aria-hidden="true"
+                      >
+                        {event.type === "arrive" ? "✓" : "↗"}
+                      </span>
+                      <div className="event-content">
+                        <strong>{event.title}</strong>
+                        <p>{event.message}</p>
+                        <time>오늘 {event.time}</time>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </aside>
+          </div>
+        </section>
+      </main>
+
+      {flow.completed && (
+        <button
+          className="feature-cue"
+          type="button"
+          onClick={() => {
+            setShowDownload(true);
+          }}
+        >
+          설치하기 <span aria-hidden="true">→</span>
+        </button>
+      )}
+
+      {showDownload && <InstallDialog onClose={() => setShowDownload(false)} />}
+
+      <div className="toast-stack" aria-live="assertive">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`toast ${toast.type === "arrive" ? "is-arrival" : ""}`}
+          >
+            <strong>{toast.title}</strong>
+            <span>{toast.message}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/landing/landing-copy.test.ts
+++ b/web/src/landing/landing-copy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import landingPageSource from "@/landing/LandingPage.tsx?raw";
+import landingMainSource from "@/landing/main.tsx?raw";
+
+describe("landing copy and presentation", () => {
+  it("introduces ImHere before inviting the visitor into the experience", () => {
+    const productIndex = landingPageSource.indexOf('id="product-title"');
+    const experienceIndex =
+      landingPageSource.indexOf("철수에게 귀가 알림을 보내보세요");
+
+    expect(productIndex).toBeGreaterThanOrEqual(0);
+    expect(experienceIndex).toBeGreaterThan(productIndex);
+  });
+
+  it("does not present the experience as an interactive browser demo", () => {
+    expect(landingPageSource).not.toContain("인터랙티브 데모");
+    expect(landingPageSource).not.toContain("브라우저 체험");
+    expect(landingPageSource).not.toContain("임꺽정");
+    expect(landingPageSource).not.toContain("BrandMark");
+  });
+
+  it("uses Pretendard without the app title-font stylesheet", () => {
+    expect(landingMainSource).toContain("pretendard");
+    expect(landingMainSource).not.toContain("typography.css");
+  });
+
+  it("opens the install dialog after the experience", () => {
+    expect(landingPageSource).toContain("설치하기");
+    expect(landingPageSource).toContain("<InstallDialog");
+  });
+});

--- a/web/src/landing/landing-flow.test.ts
+++ b/web/src/landing/landing-flow.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  initialLandingFlowState,
+  landingFlowReducer,
+} from "@/landing/landing-flow";
+
+describe("landingFlowReducer", () => {
+  it("preserves the original friend, place, and journey setup order", () => {
+    const accepted = landingFlowReducer(initialLandingFlowState, {
+      type: "accept-friend",
+    });
+    const selected = landingFlowReducer(accepted, {
+      type: "select-destination",
+      destination: "station",
+    });
+    const configured = landingFlowReducer(selected, { type: "save-place" });
+    const running = landingFlowReducer(configured, { type: "toggle-run" });
+    const arrived = landingFlowReducer(running, { type: "arrive" });
+
+    expect(accepted.step).toBe("place");
+    expect(configured).toMatchObject({
+      step: "run",
+      destination: "station",
+      placeConfigured: true,
+    });
+    expect(running.running).toBe(true);
+    expect(arrived).toMatchObject({
+      running: false,
+      progress: 1,
+      completed: true,
+    });
+  });
+
+  it("does not allow place setup before accepting the friend", () => {
+    const invalid = landingFlowReducer(initialLandingFlowState, {
+      type: "save-place",
+    });
+
+    expect(invalid).toBe(initialLandingFlowState);
+  });
+
+  it("keeps the original 100m to 300m notification range", () => {
+    const accepted = landingFlowReducer(initialLandingFlowState, {
+      type: "accept-friend",
+    });
+
+    expect(
+      landingFlowReducer(accepted, { type: "set-radius", radius: 50 }).radius,
+    ).toBe(100);
+    expect(
+      landingFlowReducer(accepted, { type: "set-radius", radius: 500 }).radius,
+    ).toBe(300);
+  });
+});

--- a/web/src/landing/landing-flow.ts
+++ b/web/src/landing/landing-flow.ts
@@ -1,0 +1,111 @@
+export type DemoStep = "friend" | "place" | "run";
+export type DestinationId = "cityhall" | "station" | "terminal";
+
+export type Destination = {
+  id: DestinationId;
+  label: string;
+  shortLabel: string;
+};
+
+export type LandingFlowState = {
+  step: DemoStep;
+  friendAccepted: boolean;
+  placeConfigured: boolean;
+  destination: DestinationId;
+  radius: number;
+  running: boolean;
+  speed: number;
+  progress: number;
+  completed: boolean;
+};
+
+export type LandingFlowAction =
+  | { type: "accept-friend" }
+  | { type: "select-destination"; destination: DestinationId }
+  | { type: "set-radius"; radius: number }
+  | { type: "save-place" }
+  | { type: "toggle-run" }
+  | { type: "set-speed"; speed: number }
+  | { type: "set-progress"; progress: number }
+  | { type: "reset-route" }
+  | { type: "arrive" };
+
+export const destinations: Destination[] = [
+  { id: "cityhall", label: "서울 시청", shortLabel: "시청" },
+  { id: "station", label: "서울역", shortLabel: "서울역" },
+  {
+    id: "terminal",
+    label: "고속 버스 터미널",
+    shortLabel: "터미널",
+  },
+];
+
+export const initialLandingFlowState: LandingFlowState = {
+  step: "friend",
+  friendAccepted: false,
+  placeConfigured: false,
+  destination: "cityhall",
+  radius: 150,
+  running: false,
+  speed: 1,
+  progress: 0,
+  completed: false,
+};
+
+export function landingFlowReducer(
+  state: LandingFlowState,
+  action: LandingFlowAction,
+): LandingFlowState {
+  switch (action.type) {
+    case "accept-friend":
+      return state.step === "friend"
+        ? { ...state, step: "place", friendAccepted: true }
+        : state;
+    case "select-destination":
+      return state.step === "place" && !state.placeConfigured
+        ? { ...state, destination: action.destination, progress: 0 }
+        : state;
+    case "set-radius":
+      return state.step === "place" && !state.placeConfigured
+        ? { ...state, radius: Math.min(300, Math.max(100, action.radius)) }
+        : state;
+    case "save-place":
+      return state.step === "place"
+        ? { ...state, step: "run", placeConfigured: true }
+        : state;
+    case "toggle-run":
+      return state.placeConfigured
+        ? {
+            ...state,
+            running: state.progress >= 1 ? true : !state.running,
+            progress: state.progress >= 1 ? 0 : state.progress,
+            completed: state.progress >= 1 ? false : state.completed,
+          }
+        : state;
+    case "set-speed":
+      return { ...state, speed: action.speed };
+    case "set-progress":
+      return {
+        ...state,
+        progress: Math.min(1, Math.max(0, action.progress)),
+      };
+    case "reset-route":
+      return {
+        ...state,
+        running: false,
+        progress: 0,
+        completed: false,
+      };
+    case "arrive":
+      return {
+        ...state,
+        running: false,
+        progress: 1,
+        completed: true,
+      };
+  }
+}
+
+export function destinationById(id: DestinationId) {
+  return destinations.find((destination) => destination.id === id)!;
+}

--- a/web/src/landing/landing-meta.test.ts
+++ b/web/src/landing/landing-meta.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import landingHtml from "../../landing/index.html?raw";
+
+describe("landing social metadata", () => {
+  it("keeps crawler-visible metadata in static HTML", () => {
+    expect(landingHtml).toContain('property="og:title"');
+    expect(landingHtml).toContain('property="og:description"');
+    expect(landingHtml).toContain('name="twitter:card" content="summary"');
+    expect(landingHtml).toContain('href="https://imhere.ratiko.co.kr/"');
+    expect(landingHtml).toContain("ImHere | 위치 기반 서비스");
+  });
+});

--- a/web/src/landing/landing.css
+++ b/web/src/landing/landing.css
@@ -1,0 +1,1108 @@
+:root {
+  color: var(--color-text);
+  background: var(--color-surface);
+  font-family: var(--font-body);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--color-text);
+  background: var(--color-surface);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  min-width: var(--touch-target-min);
+  min-height: var(--touch-target-min);
+  cursor: pointer;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+h1,
+h2,
+h3,
+p,
+span,
+button,
+label {
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.landing {
+  min-height: 100vh;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  min-height: calc(64px + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) 18px 0;
+  align-items: center;
+  justify-content: flex-start;
+  border-bottom: 1px solid var(--color-divider);
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+  backdrop-filter: blur(14px);
+}
+
+.brand {
+  display: inline-flex;
+  min-height: var(--touch-target-min);
+  align-items: center;
+  color: var(--color-text);
+  font-size: 1.08rem;
+  text-decoration: none;
+}
+
+.brand strong {
+  letter-spacing: -0.035em;
+}
+
+.product-intro {
+  display: grid;
+  min-height: calc(100dvh - 64px);
+  padding: 72px 20px;
+  place-items: center;
+  background: var(--color-surface);
+}
+
+.product-intro > div {
+  width: min(100%, 680px);
+}
+
+.product-intro h1 {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: clamp(2.25rem, 11vw, 4.25rem);
+  font-weight: 800;
+  letter-spacing: -0.055em;
+  line-height: 1.16;
+}
+
+.product-points {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 20px;
+  padding: 0;
+  margin: 30px 0 0;
+  list-style: none;
+}
+
+.product-points li {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--color-text);
+  font-size: 0.8rem;
+  font-weight: 750;
+}
+
+.product-points li::before {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary);
+  content: "";
+}
+
+.product-cta {
+  display: inline-flex;
+  max-width: 100%;
+  min-height: 52px;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 20px;
+  margin-top: 36px;
+  border-radius: var(--radius-sm);
+  color: var(--color-on-primary);
+  background: var(--color-primary);
+  font-size: 0.86rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.experience {
+  border-top: 1px solid var(--color-divider);
+  scroll-margin-top: 64px;
+}
+
+.experience-heading {
+  padding: 48px 18px 30px;
+  background: var(--color-surface);
+}
+
+.experience-heading h2 {
+  margin: 0;
+  font-size: clamp(1.75rem, 8vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.045em;
+  line-height: 1.3;
+}
+
+.experience-heading > p:last-child {
+  margin: 12px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.workspace {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.panel {
+  min-width: 0;
+  background: var(--color-surface);
+}
+
+.setup-panel,
+.activity-panel {
+  padding: 24px 18px 34px;
+}
+
+.setup-panel {
+  order: 1;
+}
+
+.map-stage {
+  position: relative;
+  order: 2;
+  height: 58vh;
+  min-height: 420px;
+  overflow: hidden;
+  border-top: 1px solid var(--color-divider);
+  background: var(--color-landing-map);
+}
+
+.activity-panel {
+  order: 3;
+  border-top: 1px solid var(--color-divider);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--color-primary);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.setup-panel > h3 {
+  max-width: 320px;
+  margin: 0 0 20px;
+  font-size: clamp(1.5rem, 7vw, 1.85rem);
+  letter-spacing: -0.045em;
+  line-height: 1.28;
+}
+
+.progress-track {
+  height: 4px;
+  margin-bottom: 24px;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--color-divider) 75%, transparent);
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-primary);
+  transition: width var(--motion-normal) ease;
+}
+
+.setup-step {
+  position: relative;
+  min-height: 58px;
+  padding: 1px 0 22px 43px;
+  color: var(--color-disabled);
+}
+
+.setup-step:not(:last-of-type)::after {
+  position: absolute;
+  top: 31px;
+  bottom: 0;
+  left: 15px;
+  width: 1px;
+  background: var(--color-divider);
+  content: "";
+}
+
+.step-number {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  display: grid;
+  width: 31px;
+  height: 31px;
+  place-items: center;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.setup-step h2 {
+  margin: 2px 0 4px;
+  font-size: 0.94rem;
+  letter-spacing: -0.025em;
+}
+
+.setup-step > p {
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.setup-step.is-active,
+.setup-step.is-complete {
+  color: var(--color-text);
+}
+
+.setup-step.is-active .step-number {
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+  background: var(--color-primary);
+}
+
+.setup-step.is-complete .step-number {
+  border-color: var(--color-success);
+  color: var(--color-on-primary);
+  background: var(--color-success);
+}
+
+.step-body {
+  margin-top: 14px;
+}
+
+.step-summary {
+  display: block;
+  margin-top: 6px;
+  color: var(--color-success);
+  font-size: 0.75rem;
+}
+
+.request-card {
+  padding: 14px;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.request-person {
+  display: flex;
+  gap: 11px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.friend-avatar {
+  display: grid;
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  color: var(--color-on-primary);
+  background: var(--color-landing-avatar);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.request-person > span:last-child,
+.live-person > span:last-child {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.request-person strong {
+  font-size: 0.86rem;
+}
+
+.request-person small,
+.live-person small {
+  color: var(--color-text-secondary);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.button-row,
+.simulation-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.button {
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  background: var(--color-surface);
+  font-size: 0.8rem;
+  font-weight: 750;
+  transition:
+    transform var(--motion-fast) ease,
+    border-color var(--motion-fast) ease,
+    background var(--motion-fast) ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: var(--color-primary);
+}
+
+.button--primary {
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  justify-content: center;
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+  background: var(--color-primary);
+}
+
+.button--quiet {
+  background: var(--color-background);
+}
+
+.button--wide {
+  width: 100%;
+}
+
+.place-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+  margin-bottom: 12px;
+}
+
+.place-options button {
+  display: grid;
+  min-width: 0;
+  min-height: 64px;
+  gap: 4px;
+  place-items: center;
+  padding: 7px 3px;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.place-options button > span {
+  color: inherit;
+  font-size: 1.05rem;
+}
+
+.place-options button.is-selected {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.setting-box {
+  padding: 13px;
+  margin-bottom: 10px;
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+}
+
+.field-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 7px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.field-label strong {
+  color: var(--color-primary);
+}
+
+input[type="range"] {
+  width: 100%;
+  min-height: var(--touch-target-min);
+  margin: -7px 0;
+  accent-color: var(--color-primary);
+}
+
+.check-row {
+  display: flex;
+  min-height: var(--touch-target-min);
+  gap: 8px;
+  align-items: center;
+  color: var(--color-text-secondary);
+  font-size: 0.74rem;
+}
+
+.check-row input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+}
+
+.simulation-actions {
+  grid-template-columns: 1fr var(--touch-target-min);
+}
+
+.icon-button {
+  padding: 0;
+  font-size: 1.15rem;
+}
+
+.speed-control {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.speed-control button {
+  flex: 1;
+  min-width: 0;
+  min-height: var(--touch-target-min);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.speed-control button.is-selected {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.journey-map {
+  position: absolute;
+  inset: 0;
+}
+
+.journey-map canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.journey-map canvas:active {
+  cursor: grabbing;
+}
+
+.map-label-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.map-place-label,
+.map-runner-label {
+  padding: 5px 8px;
+  transform: translate(-50%, -100%);
+  border: 1px solid var(--color-divider);
+  border-radius: 6px;
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-surface) 94%, transparent);
+  box-shadow: var(--shadow-card);
+  font-size: 0.67rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.map-place-label.is-selected {
+  border-color: var(--color-primary);
+  color: var(--color-on-primary);
+  background: var(--color-primary);
+}
+
+.map-runner-label {
+  border-color: color-mix(
+    in srgb,
+    var(--color-landing-avatar) 45%,
+    transparent
+  );
+  color: var(--color-on-primary);
+  background: var(--color-landing-avatar);
+}
+
+.map-toolbar {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 4;
+}
+
+.map-controls {
+  display: flex;
+  overflow: hidden;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(10px);
+}
+
+.map-controls button {
+  display: grid;
+  min-width: var(--touch-target-min);
+  min-height: var(--touch-target-min);
+  place-items: center;
+  border: 0;
+  border-right: 1px solid var(--color-divider);
+  color: var(--color-text);
+  background: transparent;
+  font-size: 1.05rem;
+}
+
+.map-controls button:last-child {
+  border-right: 0;
+}
+
+.live-card {
+  position: absolute;
+  right: 14px;
+  bottom: calc(16px + env(safe-area-inset-bottom));
+  left: 14px;
+  z-index: 5;
+  padding: 13px 14px;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(12px);
+}
+
+.live-head,
+.live-person {
+  display: flex;
+  align-items: center;
+}
+
+.live-head {
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.live-person {
+  min-width: 0;
+  gap: 9px;
+}
+
+.live-person .friend-avatar {
+  width: 36px;
+  height: 36px;
+}
+
+.live-person strong {
+  font-size: 0.78rem;
+}
+
+.live-person small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-distance {
+  flex: 0 0 auto;
+  color: var(--color-primary);
+  font-size: 0.72rem;
+}
+
+.route-progress {
+  height: 4px;
+  margin-top: 11px;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--color-divider);
+}
+
+.route-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-primary);
+  transition: width var(--motion-fast) linear;
+}
+
+.map-help {
+  display: none;
+}
+
+.map-fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  gap: 6px;
+  place-content: center;
+  padding: 24px;
+  color: var(--color-text-secondary);
+  background: var(--color-background);
+  text-align: center;
+}
+
+.map-fallback strong {
+  color: var(--color-text);
+}
+
+.activity-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.activity-head h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: -0.025em;
+}
+
+.text-button {
+  padding-inline: 6px;
+  border: 0;
+  color: var(--color-text-secondary);
+  background: transparent;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.text-button:disabled {
+  color: var(--color-disabled);
+  cursor: default;
+}
+
+.empty-state {
+  padding: 30px 12px 34px;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.empty-icon {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  margin: 0 auto 11px;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  background: var(--color-background);
+  font-size: 1.15rem;
+}
+
+.empty-state strong {
+  display: block;
+  color: var(--color-text);
+  font-size: 0.82rem;
+}
+
+.empty-state p {
+  margin: 6px 0 0;
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.timeline {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.event {
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 10px;
+  padding-bottom: 20px;
+}
+
+.event:not(:last-child)::after {
+  position: absolute;
+  top: 36px;
+  bottom: 0;
+  left: 17px;
+  width: 1px;
+  background: var(--color-divider);
+  content: "";
+}
+
+.event-icon {
+  z-index: 1;
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.event-icon.is-arrival {
+  color: var(--color-success);
+  background: var(--color-success-soft);
+}
+
+.event-content {
+  padding-top: 1px;
+}
+
+.event-content strong {
+  font-size: 0.76rem;
+}
+
+.event-content p {
+  margin: 3px 0 5px;
+  color: var(--color-text-secondary);
+  font-size: 0.7rem;
+  line-height: 1.5;
+}
+
+.event-content time {
+  color: var(--color-disabled);
+  font-size: 0.64rem;
+}
+
+.activity-foot {
+  padding: 13px 0 0;
+  margin-top: 12px;
+  border-top: 1px solid var(--color-divider);
+  color: var(--color-text-secondary);
+  font-size: 0.66rem;
+  line-height: 1.55;
+}
+
+.toast-stack {
+  position: fixed;
+  top: calc(76px + env(safe-area-inset-top));
+  right: 16px;
+  left: 16px;
+  z-index: 60;
+  display: grid;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  width: min(100%, 360px);
+  padding: 13px 14px;
+  margin-left: auto;
+  border: 1px solid var(--color-divider);
+  border-left: 4px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  animation: toast-in var(--motion-normal) ease both;
+}
+
+.toast.is-arrival {
+  border-left-color: var(--color-success);
+}
+
+.toast strong,
+.toast span {
+  display: block;
+}
+
+.toast strong {
+  font-size: 0.76rem;
+}
+
+.toast span {
+  margin-top: 3px;
+  color: var(--color-text-secondary);
+  font-size: 0.7rem;
+}
+
+.install-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  align-items: end;
+  padding-top: env(safe-area-inset-top);
+  background: color-mix(in srgb, var(--color-text) 48%, transparent);
+  animation: backdrop-in var(--motion-fast) ease both;
+}
+
+.install-dialog {
+  width: 100%;
+  padding: 20px 20px max(20px, env(safe-area-inset-bottom));
+  border-radius: 24px 24px 0 0;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  animation: dialog-in var(--motion-normal) ease both;
+}
+
+.install-dialog > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.install-dialog > header > span {
+  color: var(--color-primary);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.install-dialog__close {
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  color: var(--color-text-secondary);
+  background: var(--color-background);
+  font-size: 1.35rem;
+}
+
+.install-dialog h2 {
+  margin: 0 0 18px;
+  font-size: 1.35rem;
+  letter-spacing: -0.025em;
+}
+
+.download-actions {
+  display: grid;
+  gap: 9px;
+}
+
+.download-actions > a,
+.download-actions > button {
+  display: flex;
+  width: 100%;
+  min-height: 64px;
+  gap: 11px;
+  align-items: center;
+  padding: 0 18px;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  background: var(--color-surface);
+  text-align: left;
+  text-decoration: none;
+}
+
+.download-actions > button:disabled {
+  color: color-mix(in srgb, var(--color-text) 48%, transparent);
+  background: var(--color-background);
+  cursor: default;
+}
+
+.download-actions > * > span:last-child {
+  display: grid;
+}
+
+.download-actions small {
+  font-size: 0.65rem;
+}
+
+.download-actions strong {
+  font-size: 0.85rem;
+}
+
+.feature-cue {
+  position: fixed;
+  bottom: calc(18px + env(safe-area-inset-bottom));
+  left: 50%;
+  z-index: 55;
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  width: max-content;
+  min-height: var(--touch-target-min);
+  padding: 0 16px;
+  transform: translateX(-50%);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-pill);
+  color: var(--color-text);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+@keyframes toast-in {
+  from {
+    transform: translateY(-8px);
+    opacity: 0;
+  }
+}
+
+@keyframes backdrop-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes dialog-in {
+  from {
+    transform: translateY(24px);
+    opacity: 0;
+  }
+}
+
+@media (min-width: 560px) {
+  .install-dialog-backdrop {
+    place-items: center;
+    padding: 24px;
+  }
+
+  .install-dialog {
+    width: min(100%, 430px);
+    padding: 24px;
+    border-radius: 24px;
+  }
+
+  .experience-heading {
+    padding-right: max(24px, calc((100% - 620px) / 2));
+    padding-left: max(24px, calc((100% - 620px) / 2));
+  }
+
+  .setup-panel,
+  .activity-panel {
+    padding-right: max(24px, calc((100% - 620px) / 2));
+    padding-left: max(24px, calc((100% - 620px) / 2));
+  }
+}
+
+@media (min-width: 901px) {
+  .topbar {
+    position: relative;
+    min-height: 64px;
+    padding: 0 20px;
+  }
+
+  .workspace {
+    display: grid;
+    height: calc(100dvh - 64px);
+    grid-template-columns: 336px minmax(420px, 1fr) 304px;
+  }
+
+  .experience-heading {
+    padding: 64px max(24px, calc((100% - 1120px) / 2)) 38px;
+  }
+
+  .experience-heading > p:last-child {
+    max-width: 600px;
+  }
+
+  .panel {
+    overflow-y: auto;
+    scrollbar-color: var(--color-divider) transparent;
+    scrollbar-width: thin;
+  }
+
+  .setup-panel,
+  .activity-panel {
+    padding: 24px 20px 30px;
+  }
+
+  .setup-panel {
+    order: unset;
+    border-right: 1px solid var(--color-divider);
+  }
+
+  .map-stage {
+    order: unset;
+    height: auto;
+    min-height: 0;
+    border-top: 0;
+  }
+
+  .activity-panel {
+    order: unset;
+    border-top: 0;
+    border-left: 1px solid var(--color-divider);
+  }
+
+  .setup-panel > h3 {
+    font-size: 1.5rem;
+  }
+
+  .map-help {
+    position: absolute;
+    right: 16px;
+    bottom: 18px;
+    z-index: 3;
+    display: block;
+    color: var(--color-text-secondary);
+    font-size: 0.64rem;
+  }
+
+  .live-card {
+    right: auto;
+    left: 50%;
+    width: min(460px, calc(100% - 32px));
+    transform: translateX(-50%);
+  }
+
+  .toast-stack {
+    right: 320px;
+    left: auto;
+  }
+}
+
+@media (min-width: 901px) and (max-width: 1120px) {
+  .workspace {
+    grid-template-columns: 310px minmax(390px, 1fr) 270px;
+  }
+
+  .setup-panel,
+  .activity-panel {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .toast-stack {
+    right: 286px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/web/src/landing/main.tsx
+++ b/web/src/landing/main.tsx
@@ -1,0 +1,20 @@
+import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
+import "@/design-system/tokens.css";
+import "@/landing/landing.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { LandingPage } from "@/landing/LandingPage";
+
+const rootElement = document.getElementById("landing-root");
+
+if (rootElement === null) {
+  throw new Error("Landing root element was not found");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <LandingPage />
+  </StrictMode>,
+);

--- a/web/vite.app.config.ts
+++ b/web/vite.app.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath, URL } from "node:url";
+
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: "app",
+  base: "/app/",
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  build: {
+    outDir: "../dist/app",
+    emptyOutDir: true,
+    manifest: true,
+  },
+});

--- a/web/vite.landing.config.ts
+++ b/web/vite.landing.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath, URL } from "node:url";
+
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: "landing",
+  base: "/",
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  build: {
+    outDir: "../dist/landing",
+    emptyOutDir: true,
+    manifest: true,
+  },
+});


### PR DESCRIPTION
fixes #97

## 누가 · 언제 · 어디서 · 무엇을 · 왜 · 어떻게

- 누가: ImHere 사용자
- 언제: imhere.ratiko.co.kr 접속 및 귀가 알림 체험 시
- 어디서: React Web 랜딩과 앱 전용 빌드
- 무엇을: 위치 기반 서비스 소개, 철수 귀가 알림 체험, 후방 추적 3D 도로 지도, 설치 팝업을 추가했습니다.
- 왜: 기존 페이지의 즉시 체험 흐름을 React로 옮기되 WebView 앱과 랜딩 산출물을 섞지 않기 위해서입니다.
- 어떻게: landing/app Vite 설정·출력 경로를 분리하고 Three.js는 랜딩 엔트리에서만 번들링했습니다.

검증:
- pnpm lint
- pnpm typecheck
- vitest 20 files / 64 tests
- app/landing production build 및 build isolation check
- Chromium 320/360/390/430px, 200% 글자 확대, 전체 체험·설치 팝업

- [x] 테스트
- [ ] Breaking change