### PR TITLE
fix(web): harden onboarding flows

### DIFF
--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -22,7 +22,7 @@ describe("app router", () => {
     renderRoute("/app/auth");
     expect(
       await screen.findByRole("heading", {
-        name: "도착하면 자동으로 알려드려요",
+        name: /위치를 기반으로\s+대신\s+연락을 보낼게요\./,
       }),
     ).toBeInTheDocument();
   });

--- a/web/src/locales/ko/translation.json
+++ b/web/src/locales/ko/translation.json
@@ -103,6 +103,96 @@
       "completeDescription": "‘{{name}}’ 출입을 네이티브에서 감지합니다."
     }
   },
+  "onboarding": {
+    "auth": {
+      "eyebrow": "위치 기반 서비스 ImHere",
+      "stepsLabel": "소개 단계",
+      "stepLabel": "{{step}}단계",
+      "next": "다음",
+      "kakao": "카카오로 계속하기",
+      "google": "Google로 계속하기",
+      "inactiveWithSupport": "비활성화된 계정입니다. 도움이 필요하면 고객센터에 문의해 주세요.",
+      "inactive": "비활성화된 계정입니다.",
+      "signInFailed": "로그인하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+      "slides": {
+        "location": {
+          "title": "위치를 기반으로\n대신\n연락을 보낼게요."
+        },
+        "background": {
+          "title": "앱이 꺼져도 놓치지 않아요",
+          "description": "심지어 화면이 꺼져 있어도 괜찮아요."
+        },
+        "privacy": {
+          "title": "내 정보는 기기에 안전하게",
+          "description": "로그인과 권한은 앱에서 처리하고 웹에는 필요한 정보만 전달해요."
+        }
+      }
+    },
+    "termsConsent": {
+      "eyebrow": "약관 동의",
+      "title": "ImHere 이용을 위해 확인해 주세요",
+      "description": "선택 항목은 동의하지 않아도 서비스를 이용할 수 있어요.",
+      "loading": "약관을 불러오는 중",
+      "all": "전체 동의",
+      "required": "필수",
+      "optional": "선택",
+      "view": "보기",
+      "submit": "동의하고 계속하기",
+      "loadFailed": "약관을 불러오지 못했습니다.",
+      "saveFailed": "동의 내용을 저장하지 못했습니다."
+    },
+    "termDetail": {
+      "loading": "약관을 불러오는 중",
+      "notFound": "약관을 찾을 수 없습니다.",
+      "effectiveDate": "시행일 {{date}}",
+      "back": "돌아가기"
+    },
+    "permissionGuide": {
+      "eyebrow": "설정 안내",
+      "location": {
+        "title": "위치를 항상 허용해 주세요",
+        "description": "위치 권한을 ‘항상 허용’으로 선택하면 앱이 닫혀 있어도 도착을 감지할 수 있어요.",
+        "step": "위치 권한에서 ‘항상 허용’을 선택해 주세요."
+      },
+      "battery": {
+        "title": "배터리 제한을 해제해 주세요",
+        "description": "배터리 최적화 예외를 허용하면 백그라운드 자동 전송이 안정적으로 동작해요.",
+        "step": "ImHere의 배터리 사용 제한을 해제해 주세요."
+      },
+      "openStep": "아래 버튼을 눌러 시스템 설정을 열어 주세요.",
+      "returnStep": "앱으로 돌아오면 상태를 자동으로 다시 확인해요.",
+      "openSettings": "설정 열기",
+      "openFailed": "시스템 설정을 열지 못했습니다. 잠시 후 다시 시도해 주세요.",
+      "back": "돌아가기"
+    },
+    "permission": {
+      "eyebrow": "자동 전송 준비",
+      "title": "필요한 권한을 확인해 주세요",
+      "description": "권한 요청은 앱에서만 처리되며 언제든 설정에서 바꿀 수 있어요.",
+      "loading": "권한 상태를 확인하는 중",
+      "complete": "완료",
+      "settings": "설정",
+      "locationGuide": "위치 권한 안내",
+      "batteryGuide": "배터리 설정 안내",
+      "refresh": "상태 다시 확인",
+      "checkFailed": "권한 상태를 확인하지 못했습니다.",
+      "requestFailed": "권한을 요청하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+      "items": {
+        "location": {
+          "title": "항상 위치 허용",
+          "description": "앱이 닫혀 있어도 장소 도착을 감지해요."
+        },
+        "notification": {
+          "title": "알림 허용",
+          "description": "전송 결과와 도착 알림을 알려드려요."
+        },
+        "battery": {
+          "title": "배터리 최적화 예외",
+          "description": "Android에서 자동 전송이 중단되지 않게 해요."
+        }
+      }
+    }
+  },
   "screens": {
     "onboarding": {
       "auth": "로그인",

--- a/web/src/pages/onboarding/AuthPage.tsx
+++ b/web/src/pages/onboarding/AuthPage.tsx
@@ -1,33 +1,31 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { useBridge } from "@/bridge/bridge-context";
 import { Button } from "@/design-system";
 
-const slides = [
-  [
-    "도착하면 자동으로 알려드려요",
-    "장소와 사람을 정하면 ImHere가 자동 전송을 준비해요.",
-  ],
-  [
-    "앱이 꺼져도 놓치지 않아요",
-    "네이티브 지오펜스가 백그라운드에서 계속 동작해요.",
-  ],
-  [
-    "내 정보는 기기에 안전하게",
-    "로그인과 권한은 앱에서 처리하고 웹에는 필요한 정보만 전달해요.",
-  ],
-] as const;
-
 export default function AuthPage() {
   const bridge = useBridge();
   const navigate = useNavigate();
   const [params] = useSearchParams();
+  const { t } = useTranslation();
+  const slides = [
+    [t("onboarding.auth.slides.location.title"), null],
+    [
+      t("onboarding.auth.slides.background.title"),
+      t("onboarding.auth.slides.background.description"),
+    ],
+    [
+      t("onboarding.auth.slides.privacy.title"),
+      t("onboarding.auth.slides.privacy.description"),
+    ],
+  ] as const;
   const [step, setStep] = useState(0);
   const [loading, setLoading] = useState<"kakao" | "google" | null>(null);
   const [error, setError] = useState<string | null>(
     params.get("reason") === "inactive"
-      ? "비활성화된 계정입니다. 도움이 필요하면 고객센터에 문의해 주세요."
+      ? t("onboarding.auth.inactiveWithSupport")
       : null,
   );
   const [title, description] = slides[step];
@@ -41,7 +39,7 @@ export default function AuthPage() {
           ? await bridge.signInWithKakao()
           : await bridge.signInWithGoogle();
       if (session.authState.userStatus === "inactive") {
-        setError("비활성화된 계정입니다.");
+        setError(t("onboarding.auth.inactive"));
         return;
       }
       navigate(
@@ -51,7 +49,7 @@ export default function AuthPage() {
         { replace: true },
       );
     } catch {
-      setError("로그인하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+      setError(t("onboarding.auth.signInFailed"));
     } finally {
       setLoading(null);
     }
@@ -61,16 +59,21 @@ export default function AuthPage() {
     <main className="onboarding">
       <section className="onboarding__panel" aria-labelledby="auth-title">
         <header className="onboarding__header">
-          <p className="onboarding__eyebrow">ImHere 시작하기</p>
+          <p className="onboarding__eyebrow">{t("onboarding.auth.eyebrow")}</p>
           <h1 id="auth-title">{title}</h1>
-          <p className="onboarding__description">{description}</p>
+          {description === null ? null : (
+            <p className="onboarding__description">{description}</p>
+          )}
         </header>
-        <div className="onboarding__steps" aria-label="소개 단계">
+        <div
+          className="onboarding__steps"
+          aria-label={t("onboarding.auth.stepsLabel")}
+        >
           {slides.map((slide, index) => (
             <button
               key={slide[0]}
               className="onboarding__step"
-              aria-label={`${index + 1}단계`}
+              aria-label={t("onboarding.auth.stepLabel", { step: index + 1 })}
               aria-current={index === step ? "step" : undefined}
               onClick={() => setStep(index)}
             />
@@ -78,7 +81,7 @@ export default function AuthPage() {
         </div>
         {step < slides.length - 1 ? (
           <Button onClick={() => setStep((current) => current + 1)}>
-            다음
+            {t("onboarding.auth.next")}
           </Button>
         ) : (
           <div className="onboarding__actions">
@@ -86,21 +89,17 @@ export default function AuthPage() {
               loading={loading === "kakao"}
               onClick={() => void signIn("kakao")}
             >
-              카카오로 계속하기
+              {t("onboarding.auth.kakao")}
             </Button>
             <Button
               variant="secondary"
               loading={loading === "google"}
               onClick={() => void signIn("google")}
             >
-              Google로 계속하기
+              {t("onboarding.auth.google")}
             </Button>
           </div>
         )}
-        <p className="onboarding__notice">
-          계속하면 서비스 이용약관과 개인정보 처리방침을 확인하고 동의하는
-          단계로 이동합니다.
-        </p>
         {error === null ? null : (
           <p className="onboarding__error" role="alert">
             {error}

--- a/web/src/pages/onboarding/OnboardingPage.test.tsx
+++ b/web/src/pages/onboarding/OnboardingPage.test.tsx
@@ -1,5 +1,12 @@
 import { createMockBridge } from "@imhere/bridge-contract";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import axe from "axe-core";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -7,11 +14,55 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { BridgeProvider } from "@/bridge/BridgeProvider";
 
 import AuthPage from "./AuthPage";
+import PermissionGuidePage from "./PermissionGuidePage";
+import PermissionPage from "./PermissionPage";
+import TermDetailPage from "./TermDetailPage";
 import TermsConsentPage from "./TermsConsentPage";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
+
+const activeTerm = {
+  id: 1,
+  type: "SERVICE",
+  title: "서비스 이용약관",
+  content: "약관 내용",
+  version: 1,
+  isRequired: true,
+  effectiveDate: "2026-07-27",
+};
+
+const optionalTerm = {
+  ...activeTerm,
+  id: 2,
+  type: "MARKETING",
+  title: "마케팅 정보 수신",
+  isRequired: false,
+};
+
+function envelopeResponse(data: unknown) {
+  return new Response(
+    JSON.stringify({
+      imhereResponseCode: "SUCCESS",
+      message: "ok",
+      data,
+    }),
+  );
+}
+
+function mockTerms(terms = [activeTerm]) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(envelopeResponse(terms)));
+}
+
+function bridgeWithAccessToken() {
+  return createMockBridge({
+    getAccessToken: async () => ({
+      accessToken: "access",
+      expiresAt: null,
+    }),
+  }).bridge;
+}
 
 describe("onboarding screens", () => {
   it("shows all three auth steps and both native login choices", () => {
@@ -33,6 +84,65 @@ describe("onboarding screens", () => {
     ).toBeVisible();
   });
 
+  it.each([
+    {
+      button: "카카오로 계속하기",
+      method: "signInWithKakao",
+      status: "pending",
+      destination: "약관 화면",
+    },
+    {
+      button: "Google로 계속하기",
+      method: "signInWithGoogle",
+      status: "active",
+      destination: "권한 화면",
+    },
+  ] as const)(
+    "uses the native bridge when continuing with $button",
+    async ({ button, method, status, destination }) => {
+      const user = userEvent.setup();
+      const session = {
+        authState: { authenticated: true, userStatus: status },
+        token: { accessToken: "access", expiresAt: null },
+      };
+      const controller = createMockBridge({
+        [method]: async () => session,
+      });
+      render(
+        <BridgeProvider bridge={controller.bridge}>
+          <MemoryRouter initialEntries={["/auth"]}>
+            <Routes>
+              <Route path="/auth" element={<AuthPage />} />
+              <Route path="/terms-consent" element={<p>약관 화면</p>} />
+              <Route path="/user-permission" element={<p>권한 화면</p>} />
+            </Routes>
+          </MemoryRouter>
+        </BridgeProvider>,
+      );
+
+      await user.click(screen.getByRole("button", { name: "다음" }));
+      await user.click(screen.getByRole("button", { name: "다음" }));
+      await user.click(screen.getByRole("button", { name: button }));
+
+      expect(await screen.findByText(destination)).toBeVisible();
+      expect(controller.calls).toContainEqual({ method, args: [] });
+    },
+  );
+
+  it("shows the inactive-account recovery message from the route reason", () => {
+    render(
+      <BridgeProvider bridge={createMockBridge().bridge}>
+        <MemoryRouter initialEntries={["/auth?reason=inactive"]}>
+          <AuthPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "비활성화된 계정입니다. 도움이 필요하면 고객센터에 문의해 주세요.",
+    );
+  });
+
   it("has no automated accessibility violations on auth", async () => {
     const { container } = render(
       <BridgeProvider bridge={createMockBridge().bridge}>
@@ -44,6 +154,240 @@ describe("onboarding screens", () => {
 
     const result = await axe.run(container);
     expect(result.violations).toEqual([]);
+  });
+
+  it("has no automated accessibility violations on terms consent", async () => {
+    mockTerms();
+    const { container } = render(
+      <BridgeProvider bridge={bridgeWithAccessToken()}>
+        <MemoryRouter>
+          <TermsConsentPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    expect(
+      await screen.findByRole("checkbox", { name: /서비스 이용약관/ }),
+    ).toBeVisible();
+    const result = await axe.run(container);
+    expect(result.violations).toEqual([]);
+  });
+
+  it("submits required and optional term choices after all-agree is adjusted", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(envelopeResponse([activeTerm, optionalTerm]))
+      .mockResolvedValueOnce(envelopeResponse({}));
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <BridgeProvider bridge={bridgeWithAccessToken()}>
+        <MemoryRouter initialEntries={["/terms-consent"]}>
+          <Routes>
+            <Route path="/terms-consent" element={<TermsConsentPage />} />
+            <Route path="/user-permission" element={<p>권한 화면</p>} />
+          </Routes>
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    const all = await screen.findByRole("checkbox", { name: "전체 동의" });
+    const required = screen.getByRole("checkbox", {
+      name: /서비스 이용약관/,
+    });
+    const optional = screen.getByRole("checkbox", {
+      name: /마케팅 정보 수신/,
+    });
+    const submit = screen.getByRole("button", {
+      name: "동의하고 계속하기",
+    });
+
+    expect(submit).toBeDisabled();
+    await user.click(all);
+    expect(required).toBeChecked();
+    expect(optional).toBeChecked();
+    await user.click(optional);
+    expect(required).toBeChecked();
+    expect(optional).not.toBeChecked();
+    expect(submit).toBeEnabled();
+    expect(screen.getAllByRole("link", { name: "보기" })[0]).toHaveAttribute(
+      "href",
+      "/terms-detail/1",
+    );
+
+    await user.click(submit);
+
+    expect(await screen.findByText("권한 화면")).toBeVisible();
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      consents: [
+        { id: 1, agreed: true },
+        { id: 2, agreed: false },
+      ],
+    });
+  });
+
+  it("has no automated accessibility violations on term detail", async () => {
+    mockTerms();
+    const { container } = render(
+      <BridgeProvider bridge={bridgeWithAccessToken()}>
+        <MemoryRouter initialEntries={["/terms-detail/1"]}>
+          <Routes>
+            <Route path="/terms-detail/:termId" element={<TermDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "서비스 이용약관" }),
+    ).toBeVisible();
+    const result = await axe.run(container);
+    expect(result.violations).toEqual([]);
+  });
+
+  it("has no automated accessibility violations on permission readiness", async () => {
+    const bridge = createMockBridge({
+      getAutoSendReadiness: async () => ({
+        ready: false,
+        locationAlways: false,
+        locationService: true,
+        notification: false,
+        batteryOptimization: false,
+        missing: ["locationAlways", "notification", "batteryOptimization"],
+      }),
+    }).bridge;
+    const { container } = render(
+      <BridgeProvider bridge={bridge}>
+        <MemoryRouter>
+          <PermissionPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    expect(await screen.findByText("항상 위치 허용")).toBeVisible();
+    const result = await axe.run(container);
+    expect(result.violations).toEqual([]);
+  });
+
+  it("requests a missing permission through the native bridge and refreshes", async () => {
+    const user = userEvent.setup();
+    const controller = createMockBridge({
+      getAutoSendReadiness: async () => ({
+        ready: false,
+        locationAlways: false,
+        locationService: true,
+        notification: false,
+        batteryOptimization: false,
+        missing: ["locationAlways", "notification", "batteryOptimization"],
+      }),
+      requestPermission: async () => ({
+        permission: "locationAlways",
+        status: "granted",
+      }),
+    });
+    render(
+      <BridgeProvider bridge={controller.bridge}>
+        <MemoryRouter>
+          <PermissionPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    const locationTitle = await screen.findByText("항상 위치 허용");
+    const locationItem = locationTitle.closest("article");
+    expect(locationItem).not.toBeNull();
+    await user.click(
+      within(locationItem as HTMLElement).getByRole("button", {
+        name: "설정",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        controller.calls.filter(
+          ({ method }) => method === "getAutoSendReadiness",
+        ),
+      ).toHaveLength(2),
+    );
+    expect(controller.calls).toContainEqual({
+      method: "requestPermission",
+      args: [{ permission: "locationAlways" }],
+    });
+  });
+
+  it("keeps permission recovery available when the native request fails", async () => {
+    const user = userEvent.setup();
+    const controller = createMockBridge({
+      getAutoSendReadiness: async () => ({
+        ready: false,
+        locationAlways: false,
+        locationService: true,
+        notification: false,
+        batteryOptimization: false,
+        missing: ["locationAlways"],
+      }),
+      requestPermission: async () => {
+        throw new Error("native request failed");
+      },
+    });
+    render(
+      <BridgeProvider bridge={controller.bridge}>
+        <MemoryRouter>
+          <PermissionPage />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    const locationTitle = await screen.findByText("항상 위치 허용");
+    const locationItem = locationTitle.closest("article");
+    const settings = within(locationItem as HTMLElement).getByRole("button", {
+      name: "설정",
+    });
+    await user.click(settings);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "권한을 요청하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    );
+    expect(settings).toBeEnabled();
+  });
+
+  it.each(["location", "battery"] as const)(
+    "has no automated accessibility violations on the %s permission guide",
+    async (kind) => {
+      const { container } = render(
+        <BridgeProvider bridge={createMockBridge().bridge}>
+          <MemoryRouter>
+            <PermissionGuidePage kind={kind} />
+          </MemoryRouter>
+        </BridgeProvider>,
+      );
+
+      const result = await axe.run(container);
+      expect(result.violations).toEqual([]);
+    },
+  );
+
+  it("shows recovery feedback when system settings cannot be opened", async () => {
+    const user = userEvent.setup();
+    const bridge = createMockBridge({
+      requestPermission: async () => {
+        throw new Error("settings unavailable");
+      },
+    }).bridge;
+    render(
+      <BridgeProvider bridge={bridge}>
+        <MemoryRouter>
+          <PermissionGuidePage kind="location" />
+        </MemoryRouter>
+      </BridgeProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "설정 열기" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "시스템 설정을 열지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    );
+    expect(screen.getByRole("button", { name: "설정 열기" })).toBeEnabled();
   });
 
   it("automatically activates when there are no active terms", async () => {

--- a/web/src/pages/onboarding/PermissionGuidePage.tsx
+++ b/web/src/pages/onboarding/PermissionGuidePage.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { useBridge } from "@/bridge/bridge-context";
@@ -10,43 +12,63 @@ export default function PermissionGuidePage({
 }) {
   const bridge = useBridge();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const location = kind === "location";
+  const [opening, setOpening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function openSettings() {
-    await bridge.requestPermission({
-      permission: location ? "locationAlways" : "batteryOptimization",
-    });
+    setOpening(true);
+    setError(null);
+    try {
+      await bridge.requestPermission({
+        permission: location ? "locationAlways" : "batteryOptimization",
+      });
+    } catch {
+      setError(t("onboarding.permissionGuide.openFailed"));
+    } finally {
+      setOpening(false);
+    }
   }
 
   return (
     <main className="onboarding">
       <section className="onboarding__panel" aria-labelledby="guide-title">
         <header className="onboarding__header">
-          <p className="onboarding__eyebrow">설정 안내</p>
+          <p className="onboarding__eyebrow">
+            {t("onboarding.permissionGuide.eyebrow")}
+          </p>
           <h1 id="guide-title">
             {location
-              ? "위치를 항상 허용해 주세요"
-              : "배터리 제한을 해제해 주세요"}
+              ? t("onboarding.permissionGuide.location.title")
+              : t("onboarding.permissionGuide.battery.title")}
           </h1>
           <p className="onboarding__description">
             {location
-              ? "위치 권한을 ‘항상 허용’으로 선택하면 앱이 닫혀 있어도 도착을 감지할 수 있어요."
-              : "배터리 최적화 예외를 허용하면 백그라운드 자동 전송이 안정적으로 동작해요."}
+              ? t("onboarding.permissionGuide.location.description")
+              : t("onboarding.permissionGuide.battery.description")}
           </p>
         </header>
         <ol className="onboarding__list">
-          <li>아래 버튼을 눌러 시스템 설정을 열어 주세요.</li>
+          <li>{t("onboarding.permissionGuide.openStep")}</li>
           <li>
             {location
-              ? "위치 권한에서 ‘항상 허용’을 선택해 주세요."
-              : "ImHere의 배터리 사용 제한을 해제해 주세요."}
+              ? t("onboarding.permissionGuide.location.step")
+              : t("onboarding.permissionGuide.battery.step")}
           </li>
-          <li>앱으로 돌아오면 상태를 자동으로 다시 확인해요.</li>
+          <li>{t("onboarding.permissionGuide.returnStep")}</li>
         </ol>
-        <Button onClick={() => void openSettings()}>설정 열기</Button>
-        <Button variant="secondary" onClick={() => navigate(-1)}>
-          돌아가기
+        <Button loading={opening} onClick={() => void openSettings()}>
+          {t("onboarding.permissionGuide.openSettings")}
         </Button>
+        <Button variant="secondary" onClick={() => navigate(-1)}>
+          {t("onboarding.permissionGuide.back")}
+        </Button>
+        {error === null ? null : (
+          <p className="onboarding__error" role="alert">
+            {error}
+          </p>
+        )}
       </section>
     </main>
   );

--- a/web/src/pages/onboarding/PermissionPage.tsx
+++ b/web/src/pages/onboarding/PermissionPage.tsx
@@ -1,5 +1,6 @@
 import type { NativeBridge } from "@imhere/bridge-contract";
 import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useBridge } from "@/bridge/bridge-context";
@@ -7,30 +8,40 @@ import { Button, LoadingState } from "@/design-system";
 
 type Readiness = Awaited<ReturnType<NativeBridge["getAutoSendReadiness"]>>;
 
-const permissionCopy = {
-  locationAlways: ["항상 위치 허용", "앱이 닫혀 있어도 장소 도착을 감지해요."],
-  notification: ["알림 허용", "전송 결과와 도착 알림을 알려드려요."],
-  batteryOptimization: [
-    "배터리 최적화 예외",
-    "Android에서 자동 전송이 중단되지 않게 해요.",
-  ],
-} as const;
-
 export default function PermissionPage() {
   const bridge = useBridge();
   const navigate = useNavigate();
+  const { t } = useTranslation();
+  const permissionCopy = {
+    locationAlways: [
+      t("onboarding.permission.items.location.title"),
+      t("onboarding.permission.items.location.description"),
+    ],
+    notification: [
+      t("onboarding.permission.items.notification.title"),
+      t("onboarding.permission.items.notification.description"),
+    ],
+    batteryOptimization: [
+      t("onboarding.permission.items.battery.title"),
+      t("onboarding.permission.items.battery.description"),
+    ],
+  } as const;
   const [readiness, setReadiness] = useState<Readiness | null>(null);
+  const [requesting, setRequesting] = useState<
+    keyof typeof permissionCopy | null
+  >(null);
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
       const value = await bridge.getAutoSendReadiness();
       setReadiness(value);
+      setError(null);
       if (value.ready) navigate("/geofence", { replace: true });
     } catch {
-      setError("권한 상태를 확인하지 못했습니다.");
+      setError(t("onboarding.permission.checkFailed"));
     }
-  }, [bridge, navigate]);
+  }, [bridge, navigate, t]);
 
   useEffect(() => {
     const initialRefresh = setTimeout(() => void refresh(), 0);
@@ -49,22 +60,32 @@ export default function PermissionPage() {
   }, [bridge, refresh]);
 
   async function request(permission: keyof typeof permissionCopy) {
-    await bridge.requestPermission({ permission });
-    await refresh();
+    setRequesting(permission);
+    setError(null);
+    try {
+      await bridge.requestPermission({ permission });
+      await refresh();
+    } catch {
+      setError(t("onboarding.permission.requestFailed"));
+    } finally {
+      setRequesting(null);
+    }
   }
 
   return (
     <main className="onboarding">
       <section className="onboarding__panel" aria-labelledby="permission-title">
         <header className="onboarding__header">
-          <p className="onboarding__eyebrow">자동 전송 준비</p>
-          <h1 id="permission-title">필요한 권한을 확인해 주세요</h1>
+          <p className="onboarding__eyebrow">
+            {t("onboarding.permission.eyebrow")}
+          </p>
+          <h1 id="permission-title">{t("onboarding.permission.title")}</h1>
           <p className="onboarding__description">
-            권한 요청은 앱에서만 처리되며 언제든 설정에서 바꿀 수 있어요.
+            {t("onboarding.permission.description")}
           </p>
         </header>
         {readiness === null && error === null ? (
-          <LoadingState label="권한 상태를 확인하는 중" />
+          <LoadingState label={t("onboarding.permission.loading")} />
         ) : (
           <div className="onboarding__list">
             {Object.entries(permissionCopy).map(
@@ -84,12 +105,15 @@ export default function PermissionPage() {
                     </div>
                     <Button
                       variant={complete ? "ghost" : "secondary"}
-                      disabled={complete}
+                      disabled={complete || requesting !== null}
+                      loading={requesting === permission}
                       onClick={() =>
                         void request(permission as keyof typeof permissionCopy)
                       }
                     >
-                      {complete ? "완료" : "설정"}
+                      {complete
+                        ? t("onboarding.permission.complete")
+                        : t("onboarding.permission.settings")}
                     </Button>
                   </article>
                 );
@@ -98,10 +122,16 @@ export default function PermissionPage() {
           </div>
         )}
         <div className="onboarding__permission-actions">
-          <Link to="/location-permission-guide">위치 권한 안내</Link>
-          <Link to="/battery-optimization-guide">배터리 설정 안내</Link>
+          <Link to="/location-permission-guide">
+            {t("onboarding.permission.locationGuide")}
+          </Link>
+          <Link to="/battery-optimization-guide">
+            {t("onboarding.permission.batteryGuide")}
+          </Link>
         </div>
-        <Button onClick={() => void refresh()}>상태 다시 확인</Button>
+        <Button onClick={() => void refresh()}>
+          {t("onboarding.permission.refresh")}
+        </Button>
         {error === null ? null : (
           <p className="onboarding__error" role="alert">
             {error}

--- a/web/src/pages/onboarding/TermDetailPage.tsx
+++ b/web/src/pages/onboarding/TermDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useApiClient } from "@/api/use-api-client";
@@ -9,6 +10,7 @@ import { loadTerms, type Term } from "./terms-service";
 export default function TermDetailPage() {
   const api = useApiClient();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const { termId } = useParams();
   const [term, setTerm] = useState<Term | null>(null);
   const [error, setError] = useState(false);
@@ -29,22 +31,26 @@ export default function TermDetailPage() {
     <main className="onboarding">
       <article className="onboarding__panel" aria-labelledby="term-title">
         {term === null && !error ? (
-          <LoadingState label="약관을 불러오는 중" />
+          <LoadingState label={t("onboarding.termDetail.loading")} />
         ) : error ? (
           <p className="onboarding__error" role="alert">
-            약관을 찾을 수 없습니다.
+            {t("onboarding.termDetail.notFound")}
           </p>
         ) : (
           <>
             <header className="onboarding__header">
               <h1 id="term-title">{term?.title}</h1>
-              <p className="onboarding__meta">시행일 {term?.effectiveDate}</p>
+              <p className="onboarding__meta">
+                {t("onboarding.termDetail.effectiveDate", {
+                  date: term?.effectiveDate,
+                })}
+              </p>
             </header>
             <div className="onboarding__content">{term?.content}</div>
           </>
         )}
         <Button variant="secondary" onClick={() => navigate(-1)}>
-          돌아가기
+          {t("onboarding.termDetail.back")}
         </Button>
       </article>
     </main>

--- a/web/src/pages/onboarding/TermsConsentPage.tsx
+++ b/web/src/pages/onboarding/TermsConsentPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useApiClient } from "@/api/use-api-client";
@@ -9,6 +10,7 @@ import { activateWithTerms, loadTerms, type Term } from "./terms-service";
 export default function TermsConsentPage() {
   const api = useApiClient();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [terms, setTerms] = useState<Term[] | null>(null);
   const [agreed, setAgreed] = useState<Set<number>>(new Set());
   const [submitting, setSubmitting] = useState(false);
@@ -33,11 +35,11 @@ export default function TermsConsentPage() {
       })
       .catch((reason: unknown) => {
         if ((reason as { name?: string }).name !== "AbortError") {
-          setError("약관을 불러오지 못했습니다.");
+          setError(t("onboarding.termsConsent.loadFailed"));
         }
       });
     return () => controller.abort();
-  }, [api, navigate]);
+  }, [api, navigate, t]);
 
   function toggle(id: number) {
     setAgreed((current) => {
@@ -55,7 +57,7 @@ export default function TermsConsentPage() {
       await activateWithTerms(api, terms, agreed);
       navigate("/user-permission", { replace: true });
     } catch {
-      setError("동의 내용을 저장하지 못했습니다.");
+      setError(t("onboarding.termsConsent.saveFailed"));
     } finally {
       setSubmitting(false);
     }
@@ -65,14 +67,16 @@ export default function TermsConsentPage() {
     <main className="onboarding">
       <section className="onboarding__panel" aria-labelledby="terms-title">
         <header className="onboarding__header">
-          <p className="onboarding__eyebrow">약관 동의</p>
-          <h1 id="terms-title">ImHere 이용을 위해 확인해 주세요</h1>
+          <p className="onboarding__eyebrow">
+            {t("onboarding.termsConsent.eyebrow")}
+          </p>
+          <h1 id="terms-title">{t("onboarding.termsConsent.title")}</h1>
           <p className="onboarding__description">
-            선택 항목은 동의하지 않아도 서비스를 이용할 수 있어요.
+            {t("onboarding.termsConsent.description")}
           </p>
         </header>
         {terms === null && error === null ? (
-          <LoadingState label="약관을 불러오는 중" />
+          <LoadingState label={t("onboarding.termsConsent.loading")} />
         ) : (
           <div className="onboarding__list">
             {terms !== null && terms.length > 0 ? (
@@ -88,7 +92,7 @@ export default function TermsConsentPage() {
                     )
                   }
                 />
-                <strong>전체 동의</strong>
+                <strong>{t("onboarding.termsConsent.all")}</strong>
               </label>
             ) : null}
             {terms?.map((term) => (
@@ -99,9 +103,15 @@ export default function TermsConsentPage() {
                   onChange={() => toggle(term.id)}
                 />
                 <span>
-                  {term.isRequired ? "[필수]" : "[선택]"} {term.title}
+                  [
+                  {term.isRequired
+                    ? t("onboarding.termsConsent.required")
+                    : t("onboarding.termsConsent.optional")}
+                  ] {term.title}
                 </span>
-                <Link to={`/terms-detail/${term.id}`}>보기</Link>
+                <Link to={`/terms-detail/${term.id}`}>
+                  {t("onboarding.termsConsent.view")}
+                </Link>
               </label>
             ))}
           </div>
@@ -111,7 +121,7 @@ export default function TermsConsentPage() {
           loading={submitting}
           onClick={() => void submit()}
         >
-          동의하고 계속하기
+          {t("onboarding.termsConsent.submit")}
         </Button>
         {error === null ? null : (
           <p className="onboarding__error" role="alert">

--- a/web/src/pages/onboarding/onboarding.css
+++ b/web/src/pages/onboarding/onboarding.css
@@ -1,20 +1,19 @@
 .onboarding {
-  display: grid;
   min-height: 100dvh;
-  place-items: center;
-  padding: var(--space-6);
   color: var(--color-text);
   background: var(--color-background);
 }
 
 .onboarding__panel {
   display: grid;
-  width: min(100%, 34rem);
-  gap: var(--space-5);
-  padding: var(--space-6);
+  width: min(100%, 31rem);
+  min-height: 100dvh;
+  gap: var(--space-6);
+  align-content: center;
+  margin: 0 auto;
+  padding: calc(var(--space-8) + env(safe-area-inset-top)) var(--space-5)
+    calc(var(--space-8) + env(safe-area-inset-bottom));
   background: var(--color-surface);
-  border: 1px solid var(--color-divider);
-  border-radius: var(--radius-xl);
 }
 
 .onboarding__header,
@@ -24,10 +23,38 @@
   gap: var(--space-3);
 }
 
+.onboarding__header {
+  margin-top: 0;
+}
+
+.onboarding__header h1 {
+  max-width: 25rem;
+  margin: 0;
+  font-family: var(--font-title);
+  font-size: clamp(1.9rem, 8vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  line-height: 1.1;
+  white-space: pre-line;
+}
+
 .onboarding__eyebrow,
 .onboarding__description,
 .onboarding__meta {
+  margin: 0;
   color: var(--color-text-secondary);
+}
+
+.onboarding__eyebrow {
+  color: var(--color-primary);
+  font-size: var(--text-body-medium);
+  font-weight: 750;
+}
+
+.onboarding__description {
+  max-width: 25rem;
+  font-size: var(--text-body-large);
+  line-height: 1.65;
 }
 
 .onboarding__steps,
@@ -37,28 +64,55 @@
   gap: var(--space-2);
 }
 
-.onboarding__step {
-  width: 0.6rem;
-  height: 0.6rem;
-  padding: 0;
-  background: var(--color-divider);
-  border: 0;
-  border-radius: var(--radius-pill);
+.onboarding__steps {
+  gap: 0;
+  margin: calc(var(--space-2) * -1) 0;
 }
 
-.onboarding__step[aria-current="step"] {
-  width: 1.5rem;
+.onboarding__step {
+  position: relative;
+  display: grid;
+  width: var(--touch-target-min);
+  height: var(--touch-target-min);
+  padding: 0;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.onboarding__step::after {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-divider);
+  content: "";
+  transition:
+    width var(--motion-normal) ease,
+    background-color var(--motion-normal) ease;
+}
+
+.onboarding__step[aria-current="step"]::after {
+  width: 1.75rem;
   background: var(--color-primary);
 }
 
-.onboarding__notice,
-.onboarding__error {
-  padding: var(--space-3);
-  border-radius: var(--radius-md);
+.onboarding__step:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: -0.25rem;
 }
 
-.onboarding__notice {
-  background: var(--color-primary-soft);
+.onboarding__panel > .ds-button,
+.onboarding__actions .ds-button {
+  width: 100%;
+}
+
+.onboarding__error {
+  margin: 0;
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-body-medium);
+  line-height: 1.5;
 }
 
 .onboarding__error {
@@ -72,14 +126,70 @@
   grid-template-columns: auto 1fr auto;
   gap: var(--space-3);
   align-items: center;
-  min-height: 52px;
+  min-height: 4rem;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-divider);
 }
 
-.onboarding__term a {
+.onboarding__term input {
+  width: 1.25rem;
+  height: 1.25rem;
+  accent-color: var(--color-primary);
+}
+
+.onboarding__term a,
+.onboarding__permission-actions a {
+  min-height: var(--touch-target-min);
   color: var(--color-primary);
+  font-size: var(--text-body-medium);
+  font-weight: 700;
+}
+
+.onboarding__permission > span {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  border-radius: var(--radius-md);
+  color: var(--color-primary);
+  background: var(--color-primary-soft);
+  font-weight: 800;
 }
 
 .onboarding__content {
-  line-height: 1.7;
+  max-height: 25rem;
+  overflow: auto;
+  color: var(--color-text-secondary);
+  line-height: 1.8;
   white-space: pre-wrap;
+}
+
+@media (min-width: 48rem) {
+  .onboarding {
+    padding: var(--space-8);
+  }
+
+  .onboarding__panel {
+    min-height: calc(100dvh - 4rem);
+    padding-inline: var(--space-8);
+  }
+}
+
+@media (max-width: 21rem) {
+  .onboarding__panel {
+    gap: var(--space-5);
+    padding-inline: var(--space-4);
+  }
+
+  .onboarding__header {
+    margin-top: 0;
+  }
+
+  .onboarding__header h1 {
+    font-size: 2rem;
+  }
+
+  .onboarding__description {
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- 온보딩 전 화면 문구를 한국어 i18n 리소스로 분리
- 소셜 로그인·약관 동의·권한 안내의 브리지 오류 복구와 중복 요청 방지 강화
- 온보딩 접근성 및 상태 전이 테스트 보강
- 변경된 로그인 랜딩 문구에 라우터 테스트 정렬

## Verification
- corepack pnpm test (20 files, 76 tests)
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm bridge:check
- corepack pnpm build:app
- corepack pnpm build:landing
- corepack pnpm check:build-isolation
- changed-file Prettier check

## Manual review remaining
- Android/iOS 실기기 소셜 로그인·권한 요청·설정 복귀 흐름
- 모바일 화면 디자인 최종 승인