### PR TITLE
test(flutter): align notification detail expectations

### DIFF
--- a/test/feature/record/view/notification_detail_view_test.dart
+++ b/test/feature/record/view/notification_detail_view_test.dart
@@ -53,8 +53,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('알림 상세'), findsOneWidget);
-    expect(find.text('이동 경로'), findsOneWidget);
-    expect(find.text('/record/notifications'), findsOneWidget);
+    expect(find.text(notification.body), findsOneWidget);
+    expect(
+      find.text('${notification.senderNickname} (${notification.senderEmail})'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('상세 페이지는 알림 정보를 렌더링한다', (tester) async {
@@ -72,6 +75,6 @@ void main() {
 
     expect(find.text('도착 알림'), findsOneWidget);
     expect(find.text('홍길동 (hong@example.com)'), findsOneWidget);
-    expect(find.text('/record/notifications'), findsOneWidget);
+    expect(find.text(notification.body), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- F11 알림 상세 테스트에서 더 이상 화면에 노출하지 않는 내부 딥링크 경로 기대 제거
- 제목·본문·발신자 정보라는 현재 사용자 화면 계약을 검증하도록 변경

## Verification
- lutter analyze --no-fatal-infos --no-fatal-warnings (기존 경고 15건, exit 0)
- lutter test test/feature/record/view/notification_detail_view_test.dart (2 passed)
- lutter test (331 passed)