### PR TITLE
feat: add consent-gated analytics layer

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,21 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="false"
         tools:replace="android:allowBackup">
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="google_analytics_default_allow_analytics_storage"
+            android:value="false" />
+        <meta-data
+            android:name="google_analytics_default_allow_ad_storage"
+            android:value="false" />
+        <meta-data
+            android:name="google_analytics_default_allow_ad_user_data"
+            android:value="false" />
+        <meta-data
+            android:name="google_analytics_default_allow_ad_personalization_signals"
+            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
+    <false/>
+    <key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE</key>
+    <false/>
+    <key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE</key>
+    <false/>
+    <key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA</key>
+    <false/>
+    <key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS</key>
+    <false/>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>현재 위치를 지도에 표시하고 지오펜스 영역을 설정하기 위해 위치 정보가 필요합니다.</string>
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/lib/feature/geofence/background/geofence_delivery_pipeline.dart
+++ b/lib/feature/geofence/background/geofence_delivery_pipeline.dart
@@ -15,6 +15,7 @@ import 'package:iamhere/feature/geofence/service/fcm_arrival_service.dart';
 import 'package:iamhere/feature/geofence/service/native_geofence_registrar_interface.dart';
 import 'package:iamhere/feature/geofence/service/record_service.dart';
 import 'package:iamhere/feature/geofence/service/sms_notification_service.dart';
+import 'package:iamhere/integration/firebase/analytics_reporter.dart';
 
 class GeofenceDeliveryPipeline {
   final GeofenceDeliveryQueueDatabaseService _queue;
@@ -25,6 +26,7 @@ class GeofenceDeliveryPipeline {
   final FcmArrivalService _fcmArrivalService;
   final RecordService _recordService;
   final GeofenceRetryScheduler _retryScheduler;
+  final AnalyticsReporter _analytics;
   Future<void>? _drainInFlight;
 
   GeofenceDeliveryPipeline(
@@ -36,6 +38,7 @@ class GeofenceDeliveryPipeline {
     this._fcmArrivalService,
     this._recordService,
     this._retryScheduler,
+    this._analytics,
   );
 
   Future<void> enqueueTriggeredGeofence({
@@ -89,6 +92,7 @@ class GeofenceDeliveryPipeline {
       message: body,
       deliveryEventType: event.name,
     );
+    await _logAnalytics('geofence_triggered', {'event_type': event.name});
     await processPending();
     await _retryScheduler.scheduleNextIfNeeded();
   }
@@ -130,6 +134,10 @@ class GeofenceDeliveryPipeline {
         );
         await _queue.complete(item.id!);
         await _completeLifecycleAfterSuccess(snapshot);
+        await _logAnalytics('delivery_succeeded', {
+          'event_type': snapshot.deliveryEventType,
+          'retry_count': item.retryCount,
+        });
         AppLogger.debug('BG_QUEUE: completed geofence delivery ${item.id}');
       } else {
         await _handleRetryFailure(
@@ -170,6 +178,10 @@ class GeofenceDeliveryPipeline {
       );
       await _queue.complete(item.id!);
       await _rollbackLifecycleAfterTerminalFailure(snapshot);
+      await _logAnalytics('delivery_failed', {
+        'event_type': snapshot.deliveryEventType,
+        'retry_count': nextRetryCount,
+      });
       AppLogger.error(
         'BG_QUEUE: permanently failed geofence delivery ${item.id} ($lastError)',
       );
@@ -299,6 +311,17 @@ class GeofenceDeliveryPipeline {
   String _buildDedupeKey(int geofenceId, DeliveryEvent event) {
     final bucket = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 5000;
     return '$geofenceId:${event.name}:$bucket';
+  }
+
+  Future<void> _logAnalytics(
+    String name,
+    Map<String, Object> parameters,
+  ) async {
+    try {
+      await _analytics.logEvent(name, parameters: parameters);
+    } catch (error) {
+      AppLogger.warning('Analytics event failed: $name ($error)');
+    }
   }
 
   // ignore: unused_element

--- a/lib/infrastructure/di/di_setup.dart
+++ b/lib/infrastructure/di/di_setup.dart
@@ -10,6 +10,7 @@ import 'package:iamhere/feature/geofence/service/native_geofence_registrar_inter
 import 'package:iamhere/feature/geofence/service/sms_notification_service.dart';
 import 'package:iamhere/feature/geofence/repository/geofence_local_repository.dart';
 import 'package:iamhere/feature/geofence/service/record_service.dart';
+import 'package:iamhere/integration/firebase/analytics_reporter.dart';
 
 import 'di_setup.config.dart';
 
@@ -48,6 +49,7 @@ Future<void> enrollBaseUrlGlobally({required String baseUrl}) async {
         getIt<FcmArrivalService>(),
         getIt<RecordService>(),
         getIt<GeofenceRetryScheduler>(),
+        FirebaseAnalyticsReporter(),
       ),
     );
   }

--- a/lib/integration/firebase/analytics_reporter.dart
+++ b/lib/integration/firebase/analytics_reporter.dart
@@ -1,0 +1,29 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+abstract interface class AnalyticsReporter {
+  Future<void> setConsent(bool granted);
+
+  Future<void> logEvent(String name, {Map<String, Object>? parameters});
+}
+
+final class FirebaseAnalyticsReporter implements AnalyticsReporter {
+  FirebaseAnalyticsReporter({FirebaseAnalytics? analytics})
+    : _analytics = analytics ?? FirebaseAnalytics.instance;
+
+  final FirebaseAnalytics _analytics;
+
+  @override
+  Future<void> setConsent(bool granted) async {
+    await _analytics.setConsent(
+      analyticsStorageConsentGranted: granted,
+      adStorageConsentGranted: false,
+      adUserDataConsentGranted: false,
+      adPersonalizationSignalsConsentGranted: false,
+    );
+    await _analytics.setAnalyticsCollectionEnabled(granted);
+  }
+
+  @override
+  Future<void> logEvent(String name, {Map<String, Object>? parameters}) =>
+      _analytics.logEvent(name: name, parameters: parameters);
+}

--- a/lib/shell/bridge/bridge_handler_registry.dart
+++ b/lib/shell/bridge/bridge_handler_registry.dart
@@ -109,6 +109,7 @@ const permissionAndAppBridgeMethodNames = <String>{
   'haptic',
   'setStatusBarStyle',
   'exitApp',
+  'setAnalyticsConsent',
   'logEvent',
 };
 

--- a/lib/shell/bridge/flutter_app_bridge_handlers.dart
+++ b/lib/shell/bridge/flutter_app_bridge_handlers.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:iamhere/integration/firebase/analytics_reporter.dart';
 import 'package:iamhere/shell/bridge/bridge_handler_registry.dart';
 import 'package:iamhere/shell/bridge/generated/bridge_contract.generated.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -11,8 +11,10 @@ import 'package:url_launcher/url_launcher.dart';
 
 class FlutterAppBridgeHandlers {
   final Future<void> Function()? onExit;
+  final AnalyticsReporter _analytics;
 
-  const FlutterAppBridgeHandlers({this.onExit});
+  FlutterAppBridgeHandlers({this.onExit, AnalyticsReporter? analytics})
+    : _analytics = analytics ?? FirebaseAnalyticsReporter();
 
   Map<String, BridgeMethodHandler> build() {
     return <String, BridgeMethodHandler>{
@@ -23,6 +25,7 @@ class FlutterAppBridgeHandlers {
       'haptic': _haptic,
       'setStatusBarStyle': _setStatusBarStyle,
       'exitApp': (_) => onExit?.call() ?? SystemNavigator.pop(),
+      'setAnalyticsConsent': _setAnalyticsConsent,
       'logEvent': _logEvent,
     };
   }
@@ -94,8 +97,8 @@ class FlutterAppBridgeHandlers {
   Future<void> _logEvent(Object? params) async {
     final map = _requiredMap(params);
     final rawParameters = map['parameters'];
-    await FirebaseAnalytics.instance.logEvent(
-      name: _requiredString(map, 'name'),
+    await _analytics.logEvent(
+      _requiredString(map, 'name'),
       parameters: rawParameters is Map
           ? rawParameters.map(
               (key, value) => MapEntry(key.toString(), value as Object),
@@ -103,6 +106,9 @@ class FlutterAppBridgeHandlers {
           : null,
     );
   }
+
+  Future<void> _setAnalyticsConsent(Object? params) =>
+      _analytics.setConsent(_requiredBool(params, 'granted'));
 
   static Map<String, Object?> _requiredMap(Object? params) {
     if (params is! Map) throw const FormatException('Expected object params.');
@@ -113,6 +119,14 @@ class FlutterAppBridgeHandlers {
     final value = _requiredMap(params)[key];
     if (value is! String || value.trim().isEmpty) {
       throw FormatException('Expected non-empty string "$key".');
+    }
+    return value;
+  }
+
+  static bool _requiredBool(Object? params, String key) {
+    final value = _requiredMap(params)[key];
+    if (value is! bool) {
+      throw FormatException('Expected boolean "$key".');
     }
     return value;
   }

--- a/lib/shell/bridge/generated/bridge_contract.generated.dart
+++ b/lib/shell/bridge/generated/bridge_contract.generated.dart
@@ -37,6 +37,7 @@ const bridgeMethodNames = <String>[
   'haptic',
   'setStatusBarStyle',
   'exitApp',
+  'setAnalyticsConsent',
   'logEvent',
 ];
 
@@ -974,6 +975,26 @@ class StatusBarRequest {
 enum StatusBarStyle {
   light,
   dark,
+}
+
+class AnalyticsConsent {
+  const AnalyticsConsent({
+    required this.granted,
+  });
+
+  final bool granted;
+
+  factory AnalyticsConsent.fromJson(Map<String, Object?> json) {
+    return AnalyticsConsent(
+      granted: json['granted'] as bool,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'granted': granted,
+    };
+  }
 }
 
 class AnalyticsEvent {

--- a/test/feature/geofence/background/geofence_delivery_pipeline_test.dart
+++ b/test/feature/geofence/background/geofence_delivery_pipeline_test.dart
@@ -12,6 +12,7 @@ import 'package:iamhere/feature/geofence/service/fcm_arrival_service.dart';
 import 'package:iamhere/feature/geofence/service/native_geofence_registrar_interface.dart';
 import 'package:iamhere/feature/geofence/service/record_service.dart';
 import 'package:iamhere/feature/geofence/service/sms_notification_service.dart';
+import 'package:iamhere/integration/firebase/analytics_reporter.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -37,6 +38,7 @@ void main() {
   late MockFcmArrivalService mockFcm;
   late MockRecordService mockRecord;
   late MockGeofenceRetryScheduler mockScheduler;
+  late _FakeAnalyticsReporter analytics;
   late GeofenceDeliveryPipeline pipeline;
 
   setUp(() {
@@ -48,6 +50,7 @@ void main() {
     mockFcm = MockFcmArrivalService();
     mockRecord = MockRecordService();
     mockScheduler = MockGeofenceRetryScheduler();
+    analytics = _FakeAnalyticsReporter();
 
     pipeline = GeofenceDeliveryPipeline(
       mockQueue,
@@ -58,41 +61,50 @@ void main() {
       mockFcm,
       mockRecord,
       mockScheduler,
+      analytics,
     );
 
-    when(mockRecord.markGeofenceRecordPending(
-      geofence: anyNamed('geofence'),
-      recipientNames: anyNamed('recipientNames'),
-      deliveryKey: anyNamed('deliveryKey'),
-      message: anyNamed('message'),
-      deliveryEventType: anyNamed('deliveryEventType'),
-      retryCount: anyNamed('retryCount'),
-      lastError: anyNamed('lastError'),
-    )).thenAnswer((_) async {});
+    when(
+      mockRecord.markGeofenceRecordPending(
+        geofence: anyNamed('geofence'),
+        recipientNames: anyNamed('recipientNames'),
+        deliveryKey: anyNamed('deliveryKey'),
+        message: anyNamed('message'),
+        deliveryEventType: anyNamed('deliveryEventType'),
+        retryCount: anyNamed('retryCount'),
+        lastError: anyNamed('lastError'),
+      ),
+    ).thenAnswer((_) async {});
 
-    when(mockRecord.markGeofenceRecordCompleted(
-      geofence: anyNamed('geofence'),
-      recipientNames: anyNamed('recipientNames'),
-      deliveryKey: anyNamed('deliveryKey'),
-      message: anyNamed('message'),
-      deliveryEventType: anyNamed('deliveryEventType'),
-      retryCount: anyNamed('retryCount'),
-    )).thenAnswer((_) async {});
+    when(
+      mockRecord.markGeofenceRecordCompleted(
+        geofence: anyNamed('geofence'),
+        recipientNames: anyNamed('recipientNames'),
+        deliveryKey: anyNamed('deliveryKey'),
+        message: anyNamed('message'),
+        deliveryEventType: anyNamed('deliveryEventType'),
+        retryCount: anyNamed('retryCount'),
+      ),
+    ).thenAnswer((_) async {});
 
-    when(mockRecord.markGeofenceRecordFailed(
-      geofence: anyNamed('geofence'),
-      recipientNames: anyNamed('recipientNames'),
-      deliveryKey: anyNamed('deliveryKey'),
-      message: anyNamed('message'),
-      deliveryEventType: anyNamed('deliveryEventType'),
-      retryCount: anyNamed('retryCount'),
-      lastError: anyNamed('lastError'),
-    )).thenAnswer((_) async {});
+    when(
+      mockRecord.markGeofenceRecordFailed(
+        geofence: anyNamed('geofence'),
+        recipientNames: anyNamed('recipientNames'),
+        deliveryKey: anyNamed('deliveryKey'),
+        message: anyNamed('message'),
+        deliveryEventType: anyNamed('deliveryEventType'),
+        retryCount: anyNamed('retryCount'),
+        lastError: anyNamed('lastError'),
+      ),
+    ).thenAnswer((_) async {});
 
-    when(mockGeofenceRepo.updateActiveStatus(any, any))
-        .thenAnswer((_) async {});
-    when(mockGeofenceRepo.updateAwaitingDeparture(any, any))
-        .thenAnswer((_) async {});
+    when(
+      mockGeofenceRepo.updateActiveStatus(any, any),
+    ).thenAnswer((_) async {});
+    when(
+      mockGeofenceRepo.updateAwaitingDeparture(any, any),
+    ).thenAnswer((_) async {});
     when(mockRegistrar.unregister(any)).thenAnswer((_) async {});
     when(mockRegistrar.register(any)).thenAnswer((_) async {});
     when(mockQueue.complete(any)).thenAnswer((_) async {});
@@ -105,38 +117,41 @@ void main() {
     ).thenAnswer((_) async {});
     when(mockScheduler.scheduleNextIfNeeded()).thenAnswer((_) async {});
 
-    when(mockSms.sendSmsToRecipients(
-      phoneNumbers: anyNamed('phoneNumbers'),
-      body: anyNamed('body'),
-      location: anyNamed('location'),
-      type: anyNamed('type'),
-    )).thenAnswer((_) async => Failure('not configured'));
+    when(
+      mockSms.sendSmsToRecipients(
+        phoneNumbers: anyNamed('phoneNumbers'),
+        body: anyNamed('body'),
+        location: anyNamed('location'),
+        type: anyNamed('type'),
+      ),
+    ).thenAnswer((_) async => Failure('not configured'));
 
-    when(mockFcm.sendGeofenceNotifications(
-      receiverEmails: anyNamed('receiverEmails'),
-      body: anyNamed('body'),
-      location: anyNamed('location'),
-      type: anyNamed('type'),
-    )).thenAnswer((_) async => Failure('not configured'));
+    when(
+      mockFcm.sendGeofenceNotifications(
+        receiverEmails: anyNamed('receiverEmails'),
+        body: anyNamed('body'),
+        location: anyNamed('location'),
+        type: anyNamed('type'),
+      ),
+    ).thenAnswer((_) async => Failure('not configured'));
   });
 
   GeofenceEntity _geofence({
     int id = 42,
     String eventType = 'arrival',
     bool awaitingDeparture = false,
-  }) =>
-      GeofenceEntity(
-        id: id,
-        name: '집',
-        address: '서울 강남구',
-        lat: 37.0,
-        lng: 127.0,
-        radius: 100.0,
-        message: '',
-        contactIds: '[]',
-        eventType: eventType,
-        awaitingDeparture: awaitingDeparture,
-      );
+  }) => GeofenceEntity(
+    id: id,
+    name: '집',
+    address: '서울 강남구',
+    lat: 37.0,
+    lng: 127.0,
+    radius: 100.0,
+    message: '',
+    contactIds: '[]',
+    eventType: eventType,
+    awaitingDeparture: awaitingDeparture,
+  );
 
   GeofenceDeliveryQueueEntity _queueItem({
     int id = 1,
@@ -178,53 +193,65 @@ void main() {
   }
 
   group('GeofenceDeliveryPipeline.processPending — 수신자 없음', () {
-    test('SMS/FCM 없을 때 success 로 처리 → record completed + queue completed', () async {
-      final item = _queueItem();
-      _stubTakeDue([item]);
-      when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
+    test(
+      'SMS/FCM 없을 때 success 로 처리 → record completed + queue completed',
+      () async {
+        final item = _queueItem();
+        _stubTakeDue([item]);
+        when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
 
-      await pipeline.processPending();
+        await pipeline.processPending();
 
-      verify(mockRecord.markGeofenceRecordCompleted(
-        geofence: anyNamed('geofence'),
-        recipientNames: anyNamed('recipientNames'),
-        deliveryKey: anyNamed('deliveryKey'),
-        message: anyNamed('message'),
-        deliveryEventType: anyNamed('deliveryEventType'),
-        retryCount: anyNamed('retryCount'),
-      )).called(1);
-      verify(mockQueue.complete(item.id!)).called(1);
-      verify(mockGeofenceRepo.updateActiveStatus(42, false)).called(1);
-    });
+        verify(
+          mockRecord.markGeofenceRecordCompleted(
+            geofence: anyNamed('geofence'),
+            recipientNames: anyNamed('recipientNames'),
+            deliveryKey: anyNamed('deliveryKey'),
+            message: anyNamed('message'),
+            deliveryEventType: anyNamed('deliveryEventType'),
+            retryCount: anyNamed('retryCount'),
+          ),
+        ).called(1);
+        verify(mockQueue.complete(item.id!)).called(1);
+        verify(mockGeofenceRepo.updateActiveStatus(42, false)).called(1);
+        expect(analytics.names, contains('delivery_succeeded'));
+      },
+    );
   });
 
   group('GeofenceDeliveryPipeline.processPending — SMS 성공', () {
-    test('SMS 성공 → record completed + queue completed + geofence deactivated', () async {
-      final item = _queueItem(smsPhoneNumbers: ['01012345678']);
-      _stubTakeDue([item]);
-      when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
-      when(mockSms.sendSmsToRecipients(
-        phoneNumbers: anyNamed('phoneNumbers'),
-        body: anyNamed('body'),
-        location: anyNamed('location'),
-        type: anyNamed('type'),
-      )).thenAnswer((_) async => Success<void>(null));
+    test(
+      'SMS 성공 → record completed + queue completed + geofence deactivated',
+      () async {
+        final item = _queueItem(smsPhoneNumbers: ['01012345678']);
+        _stubTakeDue([item]);
+        when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
+        when(
+          mockSms.sendSmsToRecipients(
+            phoneNumbers: anyNamed('phoneNumbers'),
+            body: anyNamed('body'),
+            location: anyNamed('location'),
+            type: anyNamed('type'),
+          ),
+        ).thenAnswer((_) async => Success<void>(null));
 
-      await pipeline.processPending();
+        await pipeline.processPending();
 
-      verify(mockRecord.markGeofenceRecordCompleted(
-        geofence: anyNamed('geofence'),
-        recipientNames: anyNamed('recipientNames'),
-        deliveryKey: anyNamed('deliveryKey'),
-        message: anyNamed('message'),
-        deliveryEventType: anyNamed('deliveryEventType'),
-        retryCount: anyNamed('retryCount'),
-      )).called(1);
-      verify(mockQueue.complete(item.id!)).called(1);
-      verify(mockGeofenceRepo.updateActiveStatus(42, false)).called(1);
-      verify(mockRegistrar.unregister(42)).called(1);
-    });
-
+        verify(
+          mockRecord.markGeofenceRecordCompleted(
+            geofence: anyNamed('geofence'),
+            recipientNames: anyNamed('recipientNames'),
+            deliveryKey: anyNamed('deliveryKey'),
+            message: anyNamed('message'),
+            deliveryEventType: anyNamed('deliveryEventType'),
+            retryCount: anyNamed('retryCount'),
+          ),
+        ).called(1);
+        verify(mockQueue.complete(item.id!)).called(1);
+        verify(mockGeofenceRepo.updateActiveStatus(42, false)).called(1);
+        verify(mockRegistrar.unregister(42)).called(1);
+      },
+    );
   });
 
   group('GeofenceDeliveryPipeline.processPending — FCM 성공', () {
@@ -232,12 +259,14 @@ void main() {
       final item = _queueItem(serverEmails: ['user@example.com']);
       _stubTakeDue([item]);
       when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
-      when(mockFcm.sendGeofenceNotifications(
-        receiverEmails: anyNamed('receiverEmails'),
-        body: anyNamed('body'),
-        location: anyNamed('location'),
-        type: anyNamed('type'),
-      )).thenAnswer((_) async => Success<void>(null));
+      when(
+        mockFcm.sendGeofenceNotifications(
+          receiverEmails: anyNamed('receiverEmails'),
+          body: anyNamed('body'),
+          location: anyNamed('location'),
+          type: anyNamed('type'),
+        ),
+      ).thenAnswer((_) async => Success<void>(null));
 
       await pipeline.processPending();
 
@@ -255,11 +284,13 @@ void main() {
 
       await pipeline.processPending();
 
-      verify(mockQueue.reschedule(
-        id: item.id!,
-        retryCount: 1,
-        lastError: anyNamed('lastError'),
-      )).called(1);
+      verify(
+        mockQueue.reschedule(
+          id: item.id!,
+          retryCount: 1,
+          lastError: anyNamed('lastError'),
+        ),
+      ).called(1);
       verifyNever(mockQueue.complete(any));
     });
 
@@ -273,36 +304,42 @@ void main() {
       // setUp default: SMS returns Failure — triggers retry path
       await pipeline.processPending();
 
-      verify(mockRecord.markGeofenceRecordFailed(
-        geofence: anyNamed('geofence'),
-        recipientNames: anyNamed('recipientNames'),
-        deliveryKey: anyNamed('deliveryKey'),
-        message: anyNamed('message'),
-        deliveryEventType: anyNamed('deliveryEventType'),
-        retryCount: 5,
-        lastError: anyNamed('lastError'),
-      )).called(1);
+      verify(
+        mockRecord.markGeofenceRecordFailed(
+          geofence: anyNamed('geofence'),
+          recipientNames: anyNamed('recipientNames'),
+          deliveryKey: anyNamed('deliveryKey'),
+          message: anyNamed('message'),
+          deliveryEventType: anyNamed('deliveryEventType'),
+          retryCount: 5,
+          lastError: anyNamed('lastError'),
+        ),
+      ).called(1);
       verify(mockQueue.complete(item.id!)).called(1);
       verify(mockGeofenceRepo.updateActiveStatus(42, true)).called(1);
       verify(mockRegistrar.register(any)).called(1);
+      expect(analytics.names, contains('delivery_failed'));
     });
   });
 
   group('GeofenceDeliveryPipeline.processPending — both 이벤트', () {
-    test('both + arrival 성공 → awaitingDeparture=true, geofence deactivate 안 함', () async {
-      final item = _queueItem(
-        deliveryEventType: 'arrival',
-        geofenceEventType: 'both',
-      );
-      _stubTakeDue([item]);
-      when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
+    test(
+      'both + arrival 성공 → awaitingDeparture=true, geofence deactivate 안 함',
+      () async {
+        final item = _queueItem(
+          deliveryEventType: 'arrival',
+          geofenceEventType: 'both',
+        );
+        _stubTakeDue([item]);
+        when(mockQueue.claim(item.id!)).thenAnswer((_) async => true);
 
-      await pipeline.processPending();
+        await pipeline.processPending();
 
-      verify(mockGeofenceRepo.updateAwaitingDeparture(42, true)).called(1);
-      verifyNever(mockGeofenceRepo.updateActiveStatus(any, any));
-      verifyNever(mockRegistrar.unregister(any));
-    });
+        verify(mockGeofenceRepo.updateAwaitingDeparture(42, true)).called(1);
+        verifyNever(mockGeofenceRepo.updateActiveStatus(any, any));
+        verifyNever(mockRegistrar.unregister(any));
+      },
+    );
 
     test('both + departure 성공 → geofence deactivated', () async {
       final item = _queueItem(
@@ -348,4 +385,18 @@ void main() {
       verify(mockQueue.takeDue(limit: anyNamed('limit'))).called(1);
     });
   });
+}
+
+final class _FakeAnalyticsReporter implements AnalyticsReporter {
+  final events = <({String name, Map<String, Object>? parameters})>[];
+
+  List<String> get names => events.map((event) => event.name).toList();
+
+  @override
+  Future<void> logEvent(String name, {Map<String, Object>? parameters}) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> setConsent(bool granted) async {}
 }

--- a/test/integration/firebase/analytics_consent_configuration_test.dart
+++ b/test/integration/firebase/analytics_consent_configuration_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Android analytics collection and consent default to denied', () {
+    final manifest = File(
+      'android/app/src/main/AndroidManifest.xml',
+    ).readAsStringSync();
+
+    _expectAndroidMetaDataFalse(
+      manifest,
+      'firebase_analytics_collection_enabled',
+    );
+    _expectAndroidMetaDataFalse(
+      manifest,
+      'google_analytics_default_allow_analytics_storage',
+    );
+    _expectAndroidMetaDataFalse(
+      manifest,
+      'google_analytics_default_allow_ad_storage',
+    );
+    _expectAndroidMetaDataFalse(
+      manifest,
+      'google_analytics_default_allow_ad_user_data',
+    );
+    _expectAndroidMetaDataFalse(
+      manifest,
+      'google_analytics_default_allow_ad_personalization_signals',
+    );
+  });
+
+  test('iOS analytics collection and consent default to denied', () {
+    final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+
+    _expectPlistBooleanFalse(
+      infoPlist,
+      'FIREBASE_ANALYTICS_COLLECTION_ENABLED',
+    );
+    _expectPlistBooleanFalse(
+      infoPlist,
+      'GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE',
+    );
+    _expectPlistBooleanFalse(
+      infoPlist,
+      'GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE',
+    );
+    _expectPlistBooleanFalse(
+      infoPlist,
+      'GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA',
+    );
+    _expectPlistBooleanFalse(
+      infoPlist,
+      'GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS',
+    );
+  });
+}
+
+void _expectAndroidMetaDataFalse(String manifest, String key) {
+  expect(
+    manifest,
+    matches(
+      RegExp(
+        '<meta-data\\s+android:name="$key"\\s+android:value="false"\\s*/>',
+      ),
+    ),
+  );
+}
+
+void _expectPlistBooleanFalse(String infoPlist, String key) {
+  expect(infoPlist, matches(RegExp('<key>$key</key>\\s*<false/>')));
+}

--- a/test/shell/bridge/flutter_app_bridge_handlers_test.dart
+++ b/test/shell/bridge/flutter_app_bridge_handlers_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:iamhere/integration/firebase/analytics_reporter.dart';
+import 'package:iamhere/shell/bridge/flutter_app_bridge_handlers.dart';
+
+void main() {
+  test(
+    'analytics consent is delegated to Firebase before collection',
+    () async {
+      final analytics = _FakeAnalyticsReporter();
+      final handlers = FlutterAppBridgeHandlers(analytics: analytics).build();
+
+      await handlers['setAnalyticsConsent']!({'granted': true});
+
+      expect(analytics.consents, [true]);
+    },
+  );
+
+  test(
+    'analytics events are delegated without adding sensitive data',
+    () async {
+      final analytics = _FakeAnalyticsReporter();
+      final handlers = FlutterAppBridgeHandlers(analytics: analytics).build();
+
+      await handlers['logEvent']!({
+        'name': 'geofence_saved',
+        'parameters': {'event_type': 'arrival', 'mode': 'create'},
+      });
+
+      expect(analytics.events.single.name, 'geofence_saved');
+      expect(analytics.events.single.parameters, {
+        'event_type': 'arrival',
+        'mode': 'create',
+      });
+    },
+  );
+}
+
+final class _FakeAnalyticsReporter implements AnalyticsReporter {
+  final consents = <bool>[];
+  final events = <({String name, Map<String, Object>? parameters})>[];
+
+  @override
+  Future<void> logEvent(String name, {Map<String, Object>? parameters}) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> setConsent(bool granted) async {
+    consents.add(granted);
+  }
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,5 @@
+# Public web configuration. Never place NCP secret keys or AWS credentials here.
+VITE_API_BASE_URL=https://api.example.com
+VITE_NAVER_MAP_CLIENT_ID=public-naver-map-client-id
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+VITE_CLARITY_PROJECT_ID=clarity-project-id

--- a/web/packages/bridge-contract/src/bridge.test.ts
+++ b/web/packages/bridge-contract/src/bridge.test.ts
@@ -21,7 +21,7 @@ class FakeTransport implements BridgeTransport {
 
 describe("bridge contract", () => {
   it("exposes the complete method and event surface", () => {
-    expect(Object.keys(bridgeContract.methods)).toHaveLength(31);
+    expect(Object.keys(bridgeContract.methods)).toHaveLength(32);
     expect(Object.keys(bridgeContract.events)).toEqual([
       "onAppResumed",
       "onPermissionChanged",

--- a/web/packages/bridge-contract/src/contract.ts
+++ b/web/packages/bridge-contract/src/contract.ts
@@ -264,6 +264,10 @@ export const AnalyticsEvent = s.object("AnalyticsEvent", {
   parameters: s.optional(s.json),
 });
 
+export const AnalyticsConsent = s.object("AnalyticsConsent", {
+  granted: s.boolean,
+});
+
 export const PermissionChangedEvent = s.object("PermissionChangedEvent", {
   permission: PermissionType,
   status: PermissionStatus,
@@ -322,6 +326,7 @@ export const bridgeContract = {
     haptic: method(HapticRequest, null),
     setStatusBarStyle: method(StatusBarRequest, null),
     exitApp: method(null, null),
+    setAnalyticsConsent: method(AnalyticsConsent, null),
     logEvent: method(AnalyticsEvent, null),
   },
   events: {

--- a/web/src/analytics/AnalyticsProvider.tsx
+++ b/web/src/analytics/AnalyticsProvider.tsx
@@ -1,0 +1,60 @@
+import {
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { useBridge } from "@/bridge/bridge-context";
+
+import { AnalyticsClient } from "./analytics-client";
+import { AnalyticsContext } from "./analytics-context";
+import type {
+  AnalyticsEventName,
+  AnalyticsEventParameters,
+} from "./analytics-events";
+
+export function AnalyticsProvider({ children }: PropsWithChildren) {
+  const bridge = useBridge();
+  const client = useMemo(() => new AnalyticsClient(bridge), [bridge]);
+  const [ready, setReady] = useState(false);
+  const [consentGranted, setConsentGranted] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void client.synchronizeConsent().then((granted) => {
+      if (!active) return;
+      setConsentGranted(granted);
+      setReady(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, [client]);
+
+  const setConsent = useCallback(
+    async (granted: boolean) => {
+      await client.setConsent(granted);
+      setConsentGranted(granted);
+    },
+    [client],
+  );
+  const track = useCallback(
+    <Name extends AnalyticsEventName>(
+      name: Name,
+      parameters: AnalyticsEventParameters<Name>,
+    ) => client.track(name, parameters),
+    [client],
+  );
+  const value = useMemo(
+    () => ({ consentGranted, ready, setConsent, track }),
+    [consentGranted, ready, setConsent, track],
+  );
+
+  return (
+    <AnalyticsContext.Provider value={value}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}

--- a/web/src/analytics/analytics-client.test.ts
+++ b/web/src/analytics/analytics-client.test.ts
@@ -1,0 +1,141 @@
+import { createMockBridge } from "@imhere/bridge-contract";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  AnalyticsClient,
+  sanitizeAnalyticsParameters,
+} from "./analytics-client";
+import type {
+  AnalyticsEventName,
+  SafeAnalyticsParameters,
+} from "./analytics-events";
+import type { BrowserAnalytics } from "./browser-analytics";
+
+class FakeBrowserAnalytics implements BrowserAnalytics {
+  consent: boolean[] = [];
+  clarity: AnalyticsEventName[] = [];
+  google: Array<{
+    name: AnalyticsEventName;
+    parameters: SafeAnalyticsParameters;
+  }> = [];
+
+  setConsent(granted: boolean) {
+    this.consent.push(granted);
+  }
+
+  trackClarity(name: AnalyticsEventName) {
+    this.clarity.push(name);
+  }
+
+  trackGoogle(name: AnalyticsEventName, parameters: SafeAnalyticsParameters) {
+    this.google.push({ name, parameters });
+  }
+}
+
+describe("AnalyticsClient", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("does not fan out events before analytics consent", async () => {
+    const controller = createMockBridge({
+      getAuthState: async () => ({
+        authenticated: false,
+        userStatus: null,
+      }),
+    });
+    const browser = new FakeBrowserAnalytics();
+    const client = new AnalyticsClient(
+      controller.bridge,
+      browser,
+      localStorage,
+    );
+
+    await client.synchronizeConsent();
+    await client.track("screen_view", { screen: "/auth" });
+
+    expect(browser.consent).toEqual([false]);
+    expect(browser.google).toHaveLength(0);
+    expect(browser.clarity).toHaveLength(0);
+    expect(
+      controller.calls.filter((call) => call.method === "logEvent"),
+    ).toHaveLength(0);
+  });
+
+  it("fans out one safe event to GA4, Clarity, and Firebase bridge", async () => {
+    const controller = createMockBridge();
+    const browser = new FakeBrowserAnalytics();
+    const client = new AnalyticsClient(
+      controller.bridge,
+      browser,
+      localStorage,
+    );
+
+    await client.setConsent(true);
+    await client.track("geofence_saved", {
+      event_type: "arrival",
+      mode: "create",
+      repeat_type: "weekday",
+    });
+
+    expect(browser.google).toEqual([
+      {
+        name: "geofence_saved",
+        parameters: {
+          event_type: "arrival",
+          mode: "create",
+          repeat_type: "weekday",
+        },
+      },
+    ]);
+    expect(browser.clarity).toEqual(["geofence_saved"]);
+    expect(controller.calls).toContainEqual({
+      method: "logEvent",
+      args: [
+        {
+          name: "geofence_saved",
+          parameters: {
+            event_type: "arrival",
+            mode: "create",
+            repeat_type: "weekday",
+          },
+        },
+      ],
+    });
+  });
+
+  it("infers consent for an already activated member", async () => {
+    const controller = createMockBridge({
+      getAuthState: async () => ({
+        authenticated: true,
+        userStatus: "active",
+      }),
+    });
+    const browser = new FakeBrowserAnalytics();
+    const client = new AnalyticsClient(
+      controller.bridge,
+      browser,
+      localStorage,
+    );
+
+    expect(await client.synchronizeConsent()).toBe(true);
+    expect(localStorage.getItem("imhere.analytics-consent.v1")).toBe("granted");
+    expect(controller.calls).toContainEqual({
+      method: "setAnalyticsConsent",
+      args: [{ granted: true }],
+    });
+  });
+
+  it("drops sensitive parameter names before dispatch", () => {
+    expect(
+      sanitizeAnalyticsParameters({
+        address: "서울",
+        event_type: "arrival",
+        latitude: 37.5,
+        message_body: "도착",
+        retry_count: 1,
+      }),
+    ).toEqual({
+      event_type: "arrival",
+      retry_count: 1,
+    });
+  });
+});

--- a/web/src/analytics/analytics-client.ts
+++ b/web/src/analytics/analytics-client.ts
@@ -1,0 +1,78 @@
+import type { NativeBridge } from "@imhere/bridge-contract";
+
+import {
+  loadAnalyticsConsent,
+  saveAnalyticsConsent,
+} from "./analytics-consent";
+import type {
+  AnalyticsEventName,
+  AnalyticsEventParameters,
+  SafeAnalyticsParameters,
+} from "./analytics-events";
+import {
+  BrowserAnalyticsSinks,
+  type BrowserAnalytics,
+} from "./browser-analytics";
+
+const sensitiveParameter =
+  /address|body|coordinate|display.?name|email|friend|lat(itude)?|lng|longitude|message|name|phone/i;
+
+export class AnalyticsClient {
+  private consentGranted = false;
+
+  constructor(
+    private readonly bridge: NativeBridge,
+    private readonly browser: BrowserAnalytics = new BrowserAnalyticsSinks(),
+    private readonly storage: Storage = localStorage,
+  ) {}
+
+  get hasConsent() {
+    return this.consentGranted;
+  }
+
+  async synchronizeConsent() {
+    const stored = loadAnalyticsConsent(this.storage);
+    if (stored !== null) {
+      await this.setConsent(stored, false);
+      return stored;
+    }
+
+    try {
+      const auth = await this.bridge.getAuthState();
+      const inferred = auth.authenticated && auth.userStatus === "active";
+      await this.setConsent(inferred, inferred);
+      return inferred;
+    } catch {
+      await this.setConsent(false, false);
+      return false;
+    }
+  }
+
+  async setConsent(granted: boolean, persist = true) {
+    this.consentGranted = granted;
+    if (persist) saveAnalyticsConsent(granted, this.storage);
+    this.browser.setConsent(granted);
+    await this.bridge.setAnalyticsConsent({ granted }).catch(() => undefined);
+  }
+
+  async track<Name extends AnalyticsEventName>(
+    name: Name,
+    parameters: AnalyticsEventParameters<Name>,
+  ) {
+    if (!this.consentGranted) return;
+    const safeParameters = sanitizeAnalyticsParameters(parameters);
+    await Promise.allSettled([
+      Promise.resolve(this.browser.trackGoogle(name, safeParameters)),
+      Promise.resolve(this.browser.trackClarity(name)),
+      this.bridge.logEvent({ name, parameters: safeParameters }),
+    ]);
+  }
+}
+
+export function sanitizeAnalyticsParameters(
+  parameters: Record<string, boolean | number | string>,
+): SafeAnalyticsParameters {
+  return Object.fromEntries(
+    Object.entries(parameters).filter(([key]) => !sensitiveParameter.test(key)),
+  );
+}

--- a/web/src/analytics/analytics-consent.ts
+++ b/web/src/analytics/analytics-consent.ts
@@ -1,0 +1,21 @@
+const storageKey = "imhere.analytics-consent.v1";
+
+export function loadAnalyticsConsent(storage: Storage = localStorage) {
+  try {
+    const value = storage.getItem(storageKey);
+    return value === null ? null : value === "granted";
+  } catch {
+    return null;
+  }
+}
+
+export function saveAnalyticsConsent(
+  granted: boolean,
+  storage: Storage = localStorage,
+) {
+  try {
+    storage.setItem(storageKey, granted ? "granted" : "denied");
+  } catch {
+    // WebView privacy modes can make localStorage unavailable.
+  }
+}

--- a/web/src/analytics/analytics-context.ts
+++ b/web/src/analytics/analytics-context.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+
+import type {
+  AnalyticsEventName,
+  AnalyticsEventParameters,
+} from "./analytics-events";
+
+export interface AnalyticsContextValue {
+  consentGranted: boolean;
+  ready: boolean;
+  setConsent(granted: boolean): Promise<void>;
+  track<Name extends AnalyticsEventName>(
+    name: Name,
+    parameters: AnalyticsEventParameters<Name>,
+  ): Promise<void>;
+}
+
+export const AnalyticsContext = createContext<AnalyticsContextValue | null>(
+  null,
+);
+
+export function useAnalytics() {
+  const value = useContext(AnalyticsContext);
+  if (value === null) throw new Error("AnalyticsProvider is missing");
+  return value;
+}

--- a/web/src/analytics/analytics-events.ts
+++ b/web/src/analytics/analytics-events.ts
@@ -1,0 +1,53 @@
+export interface AnalyticsEventMap {
+  delivery_failed: {
+    event_type: "arrival" | "departure";
+    retry_count: number;
+  };
+  delivery_succeeded: {
+    event_type: "arrival" | "departure";
+    retry_count: number;
+  };
+  friend_request_sent: {
+    source: "search";
+  };
+  geofence_deleted: {
+    event_type: "arrival" | "departure" | "both";
+  };
+  geofence_saved: {
+    event_type: "arrival" | "departure" | "both";
+    mode: "create" | "edit";
+    repeat_type: "none" | "daily" | "weekday" | "weekend" | "custom";
+  };
+  geofence_toggled: {
+    active: boolean;
+  };
+  geofence_triggered: {
+    event_type: "arrival" | "departure";
+  };
+  login_completed: {
+    provider: "google" | "kakao";
+  };
+  login_failed: {
+    provider: "google" | "kakao";
+  };
+  login_started: {
+    provider: "google" | "kakao";
+  };
+  onboarding_ready: {
+    missing_count: number;
+  };
+  screen_view: {
+    screen: string;
+  };
+  terms_accepted: {
+    optional_count: number;
+    required_count: number;
+  };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventMap;
+
+export type AnalyticsEventParameters<Name extends AnalyticsEventName> =
+  AnalyticsEventMap[Name];
+
+export type SafeAnalyticsParameters = Record<string, boolean | number | string>;

--- a/web/src/analytics/browser-analytics.test.ts
+++ b/web/src/analytics/browser-analytics.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BrowserAnalyticsSinks } from "./browser-analytics";
+
+describe("BrowserAnalyticsSinks", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    delete window.clarity;
+    delete window.dataLayer;
+    delete window.gtag;
+    vi.unstubAllEnvs();
+  });
+
+  it("does not load GA4 or Clarity before consent", () => {
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST");
+    vi.stubEnv("VITE_CLARITY_PROJECT_ID", "clarity-test");
+
+    new BrowserAnalyticsSinks().setConsent(false);
+
+    expect(document.querySelectorAll("script")).toHaveLength(0);
+  });
+
+  it("loads both sinks only after consent with advertising denied", () => {
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST");
+    vi.stubEnv("VITE_CLARITY_PROJECT_ID", "clarity-test");
+    const sinks = new BrowserAnalyticsSinks();
+
+    sinks.setConsent(true);
+
+    expect(
+      document.querySelector<HTMLScriptElement>("#imhere-google-analytics")
+        ?.src,
+    ).toContain("googletagmanager.com/gtag/js?id=G-TEST");
+    expect(
+      document.querySelector<HTMLScriptElement>("#imhere-clarity")?.src,
+    ).toContain("clarity.ms/tag/clarity-test");
+    expect(window.dataLayer).toContainEqual([
+      "consent",
+      "update",
+      {
+        ad_personalization: "denied",
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        analytics_storage: "granted",
+      },
+    ]);
+    expect(window.clarity?.q).toContainEqual([
+      "consentv2",
+      {
+        ad_Storage: "denied",
+        analytics_Storage: "granted",
+      },
+    ]);
+  });
+});

--- a/web/src/analytics/browser-analytics.ts
+++ b/web/src/analytics/browser-analytics.ts
@@ -1,0 +1,116 @@
+import type {
+  AnalyticsEventName,
+  SafeAnalyticsParameters,
+} from "./analytics-events";
+
+type ConsentValue = "denied" | "granted";
+type GtagArguments = [command: string, target: string, value?: unknown];
+type ClarityFunction = {
+  (...args: unknown[]): void;
+  q?: unknown[][];
+};
+
+declare global {
+  interface Window {
+    clarity?: ClarityFunction;
+    dataLayer?: unknown[][];
+    gtag?: (...args: GtagArguments) => void;
+  }
+}
+
+export interface BrowserAnalytics {
+  setConsent(granted: boolean): void;
+  trackClarity(name: AnalyticsEventName): void;
+  trackGoogle(
+    name: AnalyticsEventName,
+    parameters: SafeAnalyticsParameters,
+  ): void;
+}
+
+export class BrowserAnalyticsSinks implements BrowserAnalytics {
+  private googleLoaded = false;
+  private clarityLoaded = false;
+
+  setConsent(granted: boolean) {
+    if (granted) {
+      this.loadGoogle();
+      this.loadClarity();
+    }
+
+    const analyticsStorage: ConsentValue = granted ? "granted" : "denied";
+    window.gtag?.("consent", "update", {
+      ad_personalization: "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      analytics_storage: analyticsStorage,
+    });
+    window.clarity?.("consentv2", {
+      ad_Storage: "denied",
+      analytics_Storage: analyticsStorage,
+    });
+  }
+
+  trackGoogle(name: AnalyticsEventName, parameters: SafeAnalyticsParameters) {
+    window.gtag?.("event", name, parameters);
+  }
+
+  trackClarity(name: AnalyticsEventName) {
+    window.clarity?.("event", name);
+  }
+
+  private loadGoogle() {
+    const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID?.trim();
+    if (this.googleLoaded || !measurementId) return;
+    this.googleLoaded = true;
+
+    window.dataLayer ??= [];
+    window.gtag ??= (...args) => {
+      window.dataLayer?.push(args);
+    };
+    window.gtag("consent", "default", {
+      ad_personalization: "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      analytics_storage: "denied",
+    });
+    window.gtag("consent", "update", {
+      ad_personalization: "denied",
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      analytics_storage: "granted",
+    });
+    window.gtag("js", new Date().toISOString());
+    window.gtag("config", measurementId, { send_page_view: false });
+
+    appendScript(
+      "imhere-google-analytics",
+      `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`,
+    );
+  }
+
+  private loadClarity() {
+    const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID?.trim();
+    if (this.clarityLoaded || !projectId) return;
+    this.clarityLoaded = true;
+
+    window.clarity ??= Object.assign(
+      (...args: unknown[]) => {
+        window.clarity?.q?.push(args);
+      },
+      { q: [] as unknown[][] },
+    );
+    appendScript(
+      "imhere-clarity",
+      `https://www.clarity.ms/tag/${encodeURIComponent(projectId)}`,
+    );
+  }
+}
+
+function appendScript(id: string, source: string) {
+  if (document.getElementById(id) !== null) return;
+  const script = document.createElement("script");
+  script.async = true;
+  script.id = id;
+  script.src = source;
+  document.head.append(script);
+}

--- a/web/src/app/AppRoot.tsx
+++ b/web/src/app/AppRoot.tsx
@@ -1,11 +1,20 @@
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
+import { useAnalytics } from "@/analytics/analytics-context";
 import { AppErrorBoundary } from "@/app/AppErrorBoundary";
 
 export function AppRoot() {
   const { t } = useTranslation();
+  const location = useLocation();
+  const { ready, track } = useAnalytics();
+
+  useEffect(() => {
+    if (ready) {
+      void track("screen_view", { screen: location.pathname });
+    }
+  }, [location.pathname, ready, track]);
 
   return (
     <AppErrorBoundary>

--- a/web/src/bridge/BridgeProvider.tsx
+++ b/web/src/bridge/BridgeProvider.tsx
@@ -5,6 +5,8 @@ import {
 } from "@imhere/bridge-contract";
 import { type PropsWithChildren, useEffect, useState } from "react";
 
+import { AnalyticsProvider } from "@/analytics/AnalyticsProvider";
+
 import { BridgeContext } from "./bridge-context";
 
 export function BridgeProvider({
@@ -23,7 +25,7 @@ export function BridgeProvider({
   useEffect(() => () => connection.destroy(), [connection]);
   return (
     <BridgeContext.Provider value={connection.bridge}>
-      {children}
+      <AnalyticsProvider>{children}</AnalyticsProvider>
     </BridgeContext.Provider>
   );
 }

--- a/web/src/pages/friend/FriendAddScreen.tsx
+++ b/web/src/pages/friend/FriendAddScreen.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { useApiClient } from "@/api/use-api-client";
+import { useAnalytics } from "@/analytics/analytics-context";
 import { useBridge } from "@/bridge/bridge-context";
 
 import type { UserSearchResult } from "./friend-model";
@@ -10,6 +11,7 @@ import { friendService } from "./friend-service";
 export function FriendAddScreen() {
   const api = useApiClient();
   const bridge = useBridge();
+  const analytics = useAnalytics();
   const [keyword, setKeyword] = useState("");
   const [message, setMessage] = useState("ImHere에서 친구가 되어 주세요.");
   const [results, setResults] = useState<UserSearchResult[]>([]);
@@ -46,6 +48,7 @@ export function FriendAddScreen() {
     setStatus("");
     try {
       await friendService.sendRequest(api, user.id, message.trim());
+      await analytics.track("friend_request_sent", { source: "search" });
       setStatus(`${user.nickname}님에게 친구 요청을 보냈습니다.`);
       setResults((current) => current.filter((item) => item.id !== user.id));
     } catch {
@@ -54,7 +57,7 @@ export function FriendAddScreen() {
   };
 
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <Link className="feature-page__back" to="/friend">
         ← 친구 목록
       </Link>

--- a/web/src/pages/friend/FriendListScreen.tsx
+++ b/web/src/pages/friend/FriendListScreen.tsx
@@ -90,7 +90,7 @@ export function FriendListScreen() {
   };
 
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <header className="feature-page__header">
         <div>
           <span className="feature-page__eyebrow">연락처</span>

--- a/web/src/pages/friend/FriendRequestScreen.tsx
+++ b/web/src/pages/friend/FriendRequestScreen.tsx
@@ -52,7 +52,7 @@ export function FriendRequestScreen() {
   };
 
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <Link className="feature-page__back" to="/friend">
         ← 친구 목록
       </Link>

--- a/web/src/pages/friend/FriendRestrictionScreen.tsx
+++ b/web/src/pages/friend/FriendRestrictionScreen.tsx
@@ -49,7 +49,7 @@ export function FriendRestrictionScreen() {
   };
 
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <Link className="feature-page__back" to="/friend">
         ← 친구 목록
       </Link>

--- a/web/src/pages/geofence/GeofenceFormScreen.tsx
+++ b/web/src/pages/geofence/GeofenceFormScreen.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useApiClient } from "@/api/use-api-client";
+import { useAnalytics } from "@/analytics/analytics-context";
 import { useBridge } from "@/bridge/bridge-context";
 import { BottomSheet, Button, LoadingState, TextField } from "@/design-system";
 import { MapProxyService } from "@/map/map-proxy-service";
@@ -36,6 +37,7 @@ const weekDays = [0, 1, 2, 3, 4, 5, 6];
 export function GeofenceFormScreen({ id }: { id?: number }) {
   const { t } = useTranslation();
   const bridge = useBridge();
+  const analytics = useAnalytics();
   const api = useApiClient();
   const navigate = useNavigate();
   const mapService = useMemo(() => new MapProxyService(api), [api]);
@@ -134,6 +136,11 @@ export function GeofenceFormScreen({ id }: { id?: number }) {
     setSaving(true);
     try {
       await bridge.registerGeofence(toBridgeInput(draft, recipients));
+      await analytics.track("geofence_saved", {
+        event_type: draft.eventType,
+        mode: id === undefined ? "create" : "edit",
+        repeat_type: draft.repeatType,
+      });
       setSaved(true);
     } catch {
       setErrors({ submit: t("geofence.form.saveError") });
@@ -189,6 +196,7 @@ export function GeofenceFormScreen({ id }: { id?: number }) {
 
       <form
         className="feature-form"
+        data-clarity-mask="true"
         onSubmit={(event) => {
           event.preventDefault();
           void submit();

--- a/web/src/pages/geofence/GeofenceListScreen.tsx
+++ b/web/src/pages/geofence/GeofenceListScreen.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { useAnalytics } from "@/analytics/analytics-context";
 import { useBridge } from "@/bridge/bridge-context";
 import { BottomSheet, Button, EmptyState, LoadingState } from "@/design-system";
 
@@ -12,6 +13,7 @@ import { loadGeofences } from "./geofence-service";
 export function GeofenceListScreen() {
   const { t } = useTranslation();
   const bridge = useBridge();
+  const analytics = useAnalytics();
   const navigate = useNavigate();
   const [items, setItems] = useState<Geofence[] | null>(null);
   const [readiness, setReadiness] =
@@ -57,6 +59,7 @@ export function GeofenceListScreen() {
 
   async function toggleActive(item: Geofence, active: boolean) {
     const updated = await bridge.setGeofenceActive({ id: item.id, active });
+    await analytics.track("geofence_toggled", { active });
     setItems(
       (current) =>
         current?.map((value) => (value.id === updated.id ? updated : value)) ??
@@ -67,6 +70,9 @@ export function GeofenceListScreen() {
   async function remove() {
     if (deleteTarget === null) return;
     await bridge.unregisterGeofence({ id: deleteTarget.id });
+    await analytics.track("geofence_deleted", {
+      event_type: deleteTarget.eventType,
+    });
     setItems(
       (current) => current?.filter((item) => item.id !== deleteTarget.id) ?? [],
     );
@@ -147,7 +153,7 @@ export function GeofenceListScreen() {
           onAction={() => navigate("/geofence/message")}
         />
       ) : (
-        <ul className="feature-page__list">
+        <ul className="feature-page__list" data-clarity-mask="true">
           {items.map((item) => (
             <li className="feature-page__list-card" key={item.id}>
               <div className="feature-page__row">

--- a/web/src/pages/onboarding/AuthPage.tsx
+++ b/web/src/pages/onboarding/AuthPage.tsx
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
+import { useAnalytics } from "@/analytics/analytics-context";
 import { useBridge } from "@/bridge/bridge-context";
 import { Button } from "@/design-system";
 
 export default function AuthPage() {
   const bridge = useBridge();
+  const analytics = useAnalytics();
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const { t } = useTranslation();
@@ -33,6 +35,7 @@ export default function AuthPage() {
   async function signIn(provider: "kakao" | "google") {
     setLoading(provider);
     setError(null);
+    await analytics.track("login_started", { provider });
     try {
       const session =
         provider === "kakao"
@@ -42,6 +45,10 @@ export default function AuthPage() {
         setError(t("onboarding.auth.inactive"));
         return;
       }
+      if (session.authState.userStatus === "active") {
+        await analytics.setConsent(true);
+      }
+      await analytics.track("login_completed", { provider });
       navigate(
         session.authState.userStatus === "pending"
           ? "/terms-consent"
@@ -49,6 +56,7 @@ export default function AuthPage() {
         { replace: true },
       );
     } catch {
+      await analytics.track("login_failed", { provider });
       setError(t("onboarding.auth.signInFailed"));
     } finally {
       setLoading(null);

--- a/web/src/pages/onboarding/PermissionPage.tsx
+++ b/web/src/pages/onboarding/PermissionPage.tsx
@@ -1,8 +1,9 @@
 import type { NativeBridge } from "@imhere/bridge-contract";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
+import { useAnalytics } from "@/analytics/analytics-context";
 import { useBridge } from "@/bridge/bridge-context";
 import { Button, LoadingState } from "@/design-system";
 
@@ -10,6 +11,7 @@ type Readiness = Awaited<ReturnType<NativeBridge["getAutoSendReadiness"]>>;
 
 export default function PermissionPage() {
   const bridge = useBridge();
+  const { track } = useAnalytics();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const permissionCopy = {
@@ -31,17 +33,26 @@ export default function PermissionPage() {
     keyof typeof permissionCopy | null
   >(null);
   const [error, setError] = useState<string | null>(null);
+  const readyTracked = useRef(false);
 
   const refresh = useCallback(async () => {
     try {
       const value = await bridge.getAutoSendReadiness();
       setReadiness(value);
       setError(null);
-      if (value.ready) navigate("/geofence", { replace: true });
+      if (value.ready) {
+        if (!readyTracked.current) {
+          readyTracked.current = true;
+          await track("onboarding_ready", {
+            missing_count: value.missing.length,
+          });
+        }
+        navigate("/geofence", { replace: true });
+      }
     } catch {
       setError(t("onboarding.permission.checkFailed"));
     }
-  }, [bridge, navigate, t]);
+  }, [bridge, navigate, t, track]);
 
   useEffect(() => {
     const initialRefresh = setTimeout(() => void refresh(), 0);

--- a/web/src/pages/onboarding/TermsConsentPage.tsx
+++ b/web/src/pages/onboarding/TermsConsentPage.tsx
@@ -3,12 +3,14 @@ import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useApiClient } from "@/api/use-api-client";
+import { useAnalytics } from "@/analytics/analytics-context";
 import { Button, LoadingState } from "@/design-system";
 
 import { activateWithTerms, loadTerms, type Term } from "./terms-service";
 
 export default function TermsConsentPage() {
   const api = useApiClient();
+  const { setConsent, track } = useAnalytics();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const [terms, setTerms] = useState<Term[] | null>(null);
@@ -30,6 +32,11 @@ export default function TermsConsentPage() {
         setTerms(loaded);
         if (loaded.length === 0) {
           await activateWithTerms(api, []);
+          await setConsent(true);
+          await track("terms_accepted", {
+            optional_count: 0,
+            required_count: 0,
+          });
           navigate("/user-permission", { replace: true });
         }
       })
@@ -39,7 +46,7 @@ export default function TermsConsentPage() {
         }
       });
     return () => controller.abort();
-  }, [api, navigate, t]);
+  }, [api, navigate, setConsent, t, track]);
 
   function toggle(id: number) {
     setAgreed((current) => {
@@ -55,6 +62,13 @@ export default function TermsConsentPage() {
     setSubmitting(true);
     try {
       await activateWithTerms(api, terms, agreed);
+      await setConsent(true);
+      await track("terms_accepted", {
+        optional_count: terms.filter(
+          (term) => !term.isRequired && agreed.has(term.id),
+        ).length,
+        required_count: requiredIds.length,
+      });
       navigate("/user-permission", { replace: true });
     } catch {
       setError(t("onboarding.termsConsent.saveFailed"));

--- a/web/src/pages/record/NotificationListScreen.tsx
+++ b/web/src/pages/record/NotificationListScreen.tsx
@@ -78,7 +78,7 @@ export function RecordListLayout({
   title: string;
 }) {
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <Link className="feature-page__back" to={back}>
         ← 기록
       </Link>

--- a/web/src/pages/record/RecordDetailScreen.tsx
+++ b/web/src/pages/record/RecordDetailScreen.tsx
@@ -41,7 +41,7 @@ export function RecordDetailScreen({
   const back =
     kind === "notification" ? "/record/notifications" : "/record/send-history";
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <Link className="feature-page__back" to={back}>
         ← 목록으로
       </Link>

--- a/web/src/pages/record/RecordOverviewScreen.tsx
+++ b/web/src/pages/record/RecordOverviewScreen.tsx
@@ -58,7 +58,7 @@ export function RecordOverviewScreen() {
   }, [api, bridge]);
 
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <header className="feature-page__header">
         <div>
           <span className="feature-page__eyebrow">최근 활동</span>

--- a/web/src/pages/setting/SettingPage.tsx
+++ b/web/src/pages/setting/SettingPage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { useApiClient } from "@/api/use-api-client";
+import { useAnalytics } from "@/analytics/analytics-context";
 import { useBridge } from "@/bridge/bridge-context";
 import { useTheme } from "@/design-system";
 import { loadTerms, type Term } from "@/pages/onboarding/terms-service";
@@ -20,6 +21,7 @@ type Record = BridgeMethodResult<"queryRecords">["items"][number];
 export default function SettingPage() {
   const api = useApiClient();
   const bridge = useBridge();
+  const analytics = useAnalytics();
   const navigate = useNavigate();
   const { theme, toggleTheme } = useTheme();
   const [me, setMe] = useState<UserMe>();
@@ -102,6 +104,7 @@ export default function SettingPage() {
   const signOut = async () => {
     if (!window.confirm("로그아웃할까요?")) return;
     await bridge.signOut();
+    await analytics.setConsent(false);
     navigate("/auth", { replace: true });
   };
 
@@ -116,6 +119,7 @@ export default function SettingPage() {
     try {
       await settingService.withdraw(api);
       await bridge.withdraw();
+      await analytics.setConsent(false);
       navigate("/auth", { replace: true });
     } catch {
       setStatus("회원 탈퇴에 실패했습니다.");
@@ -123,7 +127,7 @@ export default function SettingPage() {
   };
 
   return (
-    <main className="feature-page">
+    <main className="feature-page" data-clarity-mask="true">
       <header className="feature-page__header">
         <div>
           <span className="feature-page__eyebrow">내 앱 관리</span>


### PR DESCRIPTION
## Summary
- add one typed analytics client that fans out to GA4, Clarity, and Firebase
- keep analytics disabled until terms consent and revoke it on sign-out/withdrawal
- mask sensitive screens and strip sensitive event parameters
- report geofence trigger and delivery outcomes from Flutter background execution
- add Android/iOS collection defaults, bridge contract support, and tests

## Verification
- Web lint/typecheck/bridge check
- Web tests: 82 passed
- app + landing production builds and isolation check
- Flutter tests: 335 passed
- Flutter analyze: 15 existing warnings/info, no new errors